### PR TITLE
More robust number_eltype

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.8.1"
+version = "0.8.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -578,7 +578,7 @@ Numeric element type of the a nested representation of a point or a vector.
 To be used in conjuntion with [`allocate`](@ref) or [`allocate_result`](@ref).
 """
 number_eltype(x) = eltype(x)
-function number_eltype(x::AbstractArray{<:AbstractArray})
+function number_eltype(x::AbstractArray)
     T = typeof(reduce(+, one(number_eltype(eti)) for eti ∈ x))
     return T
 end

--- a/test/allocation.jl
+++ b/test/allocation.jl
@@ -42,11 +42,12 @@ end
     @test combine_allocation_promotion_functions(complex, identity) === complex
     @test combine_allocation_promotion_functions(complex, complex) === complex
 
-    @test number_eltype([2.0]) == Float64
-    @test number_eltype([[2.0], [3]]) == Float64
-    @test number_eltype([[2], [3.0]]) == Float64
-    @test number_eltype([[2], [3]]) == Int
-    @test number_eltype(([2.0], [3])) == Float64
-    @test number_eltype(([2], [3.0])) == Float64
-    @test number_eltype(([2], [3])) == Int
+    @test number_eltype([2.0]) === Float64
+    @test number_eltype([[2.0], [3]]) === Float64
+    @test number_eltype([[2], [3.0]]) === Float64
+    @test number_eltype([[2], [3]]) === Int
+    @test number_eltype(([2.0], [3])) === Float64
+    @test number_eltype(([2], [3.0])) === Float64
+    @test number_eltype(([2], [3])) === Int
+    @test number_eltype(Any[[2.0], [3.0]]) === Float64
 end


### PR DESCRIPTION
This should make `number_eltype` work in cases where the type of elements in an array is inferred as `Any`.