### PR TITLE
More rigorous size tests before allocation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.9.3"
+version = "0.10.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.9.2"
+version = "0.9.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.10.0"
+version = "0.9.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -92,22 +92,12 @@ end
 
 function allocate_result(M::AbstractEmbeddedManifold, f::typeof(embed), x...)
     T = allocate_result_type(M, f, x)
-    return allocate(x[end], T, representation_size(decorated_manifold(M)))
+    return allocate(x[1], T, representation_size(decorated_manifold(M)))
 end
 
 function allocate_result(M::AbstractEmbeddedManifold, f::typeof(project), x...)
     T = allocate_result_type(M, f, x)
-    return allocate(x[end], T, representation_size(base_manifold(M)))
-end
-
-function allocate_result(M::EmbeddedManifold, f::typeof(embed), x...)
-    T = allocate_result_type(M, f, x)
-    return allocate(x[end], T, representation_size(get_embedding(M)))
-end
-
-function allocate_result(M::EmbeddedManifold, f::typeof(project), x...)
-    T = allocate_result_type(M, f, x)
-    return allocate(x[end], T, representation_size(base_manifold(M)))
+    return allocate(x[1], T, representation_size(base_manifold(M)))
 end
 
 """
@@ -207,18 +197,6 @@ get_embedding(::EmbeddedManifold)
 function get_embedding(M::EmbeddedManifold)
     return M.embedding
 end
-
-function project(M::EmbeddedManifold, p)
-    q = allocate_result(M, project, p)
-    project!(M, q, p)
-    return q
-end
-function project(M::EmbeddedManifold, p, X)
-    Y = allocate_result(M, project, p, X)
-    project!(M, Y, p, X)
-    return Y
-end
-
 
 function show(io::IO, M::EmbeddedManifold{𝔽,MT,NT}) where {𝔽,MT<:Manifold{𝔽},NT<:Manifold}
     return print(io, "EmbeddedManifold($(M.manifold), $(M.embedding))")

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -17,7 +17,7 @@ functions of this type get, in the semi-transparent way of the
 [`AbstractDecoratorManifold`](@ref), passed on to the embedding.
 
 !!! note
-    
+
     Points on an `AbstractEmbeddedManifold` are still represented using representation
     of the embedded manifold. Use [`embed`](@ref) to go to the representation of the embedding
     and [`project`](@ref) to go the other way.
@@ -131,6 +131,8 @@ check whether a point `p` is a valid point on the [`AbstractEmbeddedManifold`](@
 i.e. that `embed(M, p)` is a valid point on the embedded manifold.
 """
 function check_manifold_point(M::AbstractEmbeddedManifold, p; kwargs...)
+    mse = check_size(M,p)
+    mse === nothing || return mse
     q = embed(M, p)
     return invoke(
         check_manifold_point,
@@ -159,6 +161,8 @@ function check_tangent_vector(
         mpe === nothing || return mpe
     end
     q = embed(M, p)
+    mse = check_size(M,p,X)
+    mse === nothing || return mse
     Y = embed(M, p, X)
     return invoke(
         check_tangent_vector,

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -238,6 +238,13 @@ function decorator_transparent_dispatch(
     return Val(:parent)
 end
 function decorator_transparent_dispatch(
+    ::typeof(embed),
+    ::EmbeddedManifold,
+    args...,
+)
+    return Val(:parent)
+end
+function decorator_transparent_dispatch(
     ::typeof(embed!),
     ::AbstractEmbeddedManifold,
     args...,
@@ -431,6 +438,13 @@ end
 function decorator_transparent_dispatch(
     ::typeof(project),
     ::AbstractEmbeddedManifold,
+    args...,
+)
+    return Val(:parent)
+end
+function decorator_transparent_dispatch(
+    ::typeof(project),
+    ::EmbeddedManifold,
     args...,
 )
     return Val(:parent)

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -131,7 +131,7 @@ check whether a point `p` is a valid point on the [`AbstractEmbeddedManifold`](@
 i.e. that `embed(M, p)` is a valid point on the embedded manifold.
 """
 function check_manifold_point(M::AbstractEmbeddedManifold, p; kwargs...)
-    mse = check_size(M,p)
+    mse = check_size(M, p)
     mse === nothing || return mse
     q = embed(M, p)
     return invoke(
@@ -161,7 +161,7 @@ function check_tangent_vector(
         mpe === nothing || return mpe
     end
     q = embed(M, p)
-    mse = check_size(M,p,X)
+    mse = check_size(M, p, X)
     mse === nothing || return mse
     Y = embed(M, p, X)
     return invoke(

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -97,7 +97,7 @@ end
 
 function allocate_result(M::AbstractEmbeddedManifold, f::typeof(embed), x...)
     T = allocate_result_type(M, f, x)
-    return allocate(x[end], T, representation_size(decorated_manifold(M)))
+    return allocate(x[end], T, representation_size(get_embedding(M)))
 end
 
 function allocate_result(M::AbstractEmbeddedManifold, f::typeof(project), x...)
@@ -123,52 +123,7 @@ type the internally stored enhanced manifold `M.manifold` is returned.
 """
 base_manifold(M::EmbeddedManifold, d::Val{N} = Val(-1)) where {N} = M.manifold
 
-
-"""
-    check_manifold_point(M::AbstractEmbeddedManifold, p; kwargs)
-
-check whether a point `p` is a valid point on the [`AbstractEmbeddedManifold`](@ref),
-i.e. that `embed(M, p)` is a valid point on the embedded manifold.
-"""
-function check_manifold_point(M::AbstractEmbeddedManifold, p; kwargs...)
-    return invoke(
-        check_manifold_point,
-        Tuple{typeof(get_embedding(M)),typeof(p)},
-        get_embedding(M),
-        p;
-        kwargs...,
-    )
-end
-
-"""
-    check_tangent_vector(M::AbstractEmbeddedManifold, p, X; check_base_point = true, kwargs...)
-
-check that `embed(M, p, X)` is a valid tangent to `embed(M, p)`, where `check_base_point`
-determines whether the validity of `p` is checked, too.
-"""
-function check_tangent_vector(
-    M::AbstractEmbeddedManifold,
-    p,
-    X;
-    check_base_point = true,
-    kwargs...,
-)
-    if check_base_point
-        mpe = check_manifold_point(M, p; kwargs...)
-        mpe === nothing || return mpe
-    end
-    return invoke(
-        check_tangent_vector,
-        Tuple{typeof(get_embedding(M)),typeof(p),typeof(X)},
-        get_embedding(M),
-        p,
-        X;
-        check_base_point = check_base_point,
-        kwargs...,
-    )
-end
-
-decorated_manifold(M::AbstractEmbeddedManifold) = M.embedding
+decorated_manifold(M::AbstractEmbeddedManifold) = base_manifold(M)
 
 """
     get_embedding(M::AbstractEmbeddedManifold)
@@ -178,7 +133,7 @@ Return the [`Manifold`](@ref) `N` an [`AbstractEmbeddedManifold`](@ref) is embed
 get_embedding(::AbstractEmbeddedManifold)
 
 @decorator_transparent_function function get_embedding(M::AbstractEmbeddedManifold)
-    return decorated_manifold(M)
+    return M.embedding
 end
 
 function show(
@@ -208,15 +163,17 @@ function decorator_transparent_dispatch(
     ::AbstractEmbeddedManifold,
     args...,
 )
-    return Val(:intransparent)
+    return Val(:transparent)
 end
+
 function decorator_transparent_dispatch(
     ::typeof(check_tangent_vector),
     ::AbstractEmbeddedManifold,
     args...,
 )
-    return Val(:intransparent)
+    return Val(:transparent)
 end
+
 function decorator_transparent_dispatch(
     ::typeof(embed),
     ::AbstractEmbeddedManifold,

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -175,6 +175,17 @@ end
 
 decorated_manifold(M::EmbeddedManifold) = M.embedding
 
+function embed(M::EmbeddedManifold, p)
+    q = allocate_result(M, embed, p)
+    embed!(M, q, p)
+    return q
+end
+function embed(M::EmbeddedManifold, p, X)
+    Y = allocate_result(M, embed, p, X)
+    embed!(M, Y, p, X)
+    return Y
+end
+
 """
     get_embedding(M::AbstractEmbeddedManifold)
 
@@ -196,6 +207,18 @@ get_embedding(::EmbeddedManifold)
 function get_embedding(M::EmbeddedManifold)
     return M.embedding
 end
+
+function project(M::EmbeddedManifold, p)
+    q = allocate_result(M, project, p)
+    project!(M, q, p)
+    return q
+end
+function project(M::EmbeddedManifold, p, X)
+    Y = allocate_result(M, project, p, X)
+    project!(M, Y, p, X)
+    return Y
+end
+
 
 function show(io::IO, M::EmbeddedManifold{𝔽,MT,NT}) where {𝔽,MT<:Manifold{𝔽},NT<:Manifold}
     return print(io, "EmbeddedManifold($(M.manifold), $(M.embedding))")
@@ -233,13 +256,6 @@ end
 function decorator_transparent_dispatch(
     ::typeof(embed),
     ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(embed),
-    ::EmbeddedManifold,
     args...,
 )
     return Val(:parent)
@@ -438,13 +454,6 @@ end
 function decorator_transparent_dispatch(
     ::typeof(project),
     ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(project),
-    ::EmbeddedManifold,
     args...,
 )
     return Val(:parent)

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -165,17 +165,6 @@ end
 
 decorated_manifold(M::EmbeddedManifold) = M.embedding
 
-function embed(M::EmbeddedManifold, p)
-    q = allocate_result(M, embed, p)
-    embed!(M, q, p)
-    return q
-end
-function embed(M::EmbeddedManifold, p, X)
-    Y = allocate_result(M, embed, p, X)
-    embed!(M, Y, p, X)
-    return Y
-end
-
 """
     get_embedding(M::AbstractEmbeddedManifold)
 

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -19,7 +19,7 @@ functions of this type get, in the semi-transparent way of the
 !!! note
 
     Points on an `AbstractEmbeddedManifold` are represented using representation
-    of the embedded manifold. A [`check_manifold_point`](@ref) should first invoke
+    of the embedding. A [`check_manifold_point`](@ref) should first invoke
     the test of the embedding and then test further constraints for the embedded manifold.
 """
 abstract type AbstractEmbeddedManifold{𝔽,T<:AbstractEmbeddingType} <:

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -14,7 +14,8 @@ The embedding is further specified by an [`AbstractEmbeddingType`](@ref).
 
 This means, that technically an embedded manifold is a decorator for the embedding, i.e.
 functions of this type get, in the semi-transparent way of the
-[`AbstractDecoratorManifold`](@ref), passed on to the embedding.
+[`AbstractDecoratorManifold`](@ref), passed on to the embedding. This is in contrast with
+[`EmbeddedManifold`](@ref) that decorates the embedded manifold.
 
 !!! note
 
@@ -201,7 +202,7 @@ function show(io::IO, M::EmbeddedManifold{𝔽,MT,NT}) where {𝔽,MT<:Manifold{
 end
 
 function default_decorator_dispatch(M::EmbeddedManifold)
-    return default_embedding_dispatch(M)
+    return Val(true)
 end
 
 @doc doc"""
@@ -214,8 +215,6 @@ This is used by the [`AbstractDecoratorManifold`](@ref) within
 By default this is set to `Val(false)`.
 """
 default_embedding_dispatch(M::AbstractEmbeddedManifold) = Val(false)
-
-default_embedding_dispatch(M::EmbeddedManifold) = Val(true)
 
 function decorator_transparent_dispatch(
     ::typeof(check_manifold_point),

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -196,10 +196,7 @@ function get_embedding(M::EmbeddedManifold)
     return M.embedding
 end
 
-function show(
-    io::IO,
-    M::EmbeddedManifold{𝔽,MT,NT},
-) where {𝔽,MT<:Manifold{𝔽},NT<:Manifold}
+function show(io::IO, M::EmbeddedManifold{𝔽,MT,NT}) where {𝔽,MT<:Manifold{𝔽},NT<:Manifold}
     return print(io, "EmbeddedManifold($(M.manifold), $(M.embedding))")
 end
 

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -18,9 +18,9 @@ functions of this type get, in the semi-transparent way of the
 
 !!! note
 
-    Points on an `AbstractEmbeddedManifold` are still represented using representation
-    of the embedded manifold. Use [`embed`](@ref) to go to the representation of the embedding
-    and [`project`](@ref) to go the other way.
+    Points on an `AbstractEmbeddedManifold` are represented using representation
+    of the embedded manifold. A [`check_manifold_point`](@ref) should first invoke
+    the test of the embedding and then test further constraints for the embedded manifold.
 """
 abstract type AbstractEmbeddedManifold{𝔽,T<:AbstractEmbeddingType} <:
               AbstractDecoratorManifold{𝔽} end
@@ -131,14 +131,11 @@ check whether a point `p` is a valid point on the [`AbstractEmbeddedManifold`](@
 i.e. that `embed(M, p)` is a valid point on the embedded manifold.
 """
 function check_manifold_point(M::AbstractEmbeddedManifold, p; kwargs...)
-    mse = check_size(M, p)
-    mse === nothing || return mse
-    q = embed(M, p)
     return invoke(
         check_manifold_point,
-        Tuple{typeof(get_embedding(M)),typeof(q)},
+        Tuple{typeof(get_embedding(M)),typeof(p)},
         get_embedding(M),
-        q;
+        p;
         kwargs...,
     )
 end
@@ -160,16 +157,12 @@ function check_tangent_vector(
         mpe = check_manifold_point(M, p; kwargs...)
         mpe === nothing || return mpe
     end
-    q = embed(M, p)
-    mse = check_size(M, p, X)
-    mse === nothing || return mse
-    Y = embed(M, p, X)
     return invoke(
         check_tangent_vector,
-        Tuple{typeof(get_embedding(M)),typeof(q),typeof(Y)},
+        Tuple{typeof(get_embedding(M)),typeof(p),typeof(X)},
         get_embedding(M),
-        q,
-        Y;
+        p,
+        X;
         check_base_point = check_base_point,
         kwargs...,
     )

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -239,6 +239,40 @@ type.
 check_tangent_vector(M::Manifold, p, X; kwargs...) = nothing
 
 """
+    check_size(M::Manifold, p)
+    check_size(M::Manifold, p, X)
+
+Check whether `p` has the right [`representation_size`](@ref) for a [`Manifold`](@ref) `M`.
+Additionally if a tangent vector is given, both `p` and `X` are checked to be of
+corresponding correct representation sizes for points and tangent vectors on `M`.
+
+By default, `check_size` returns `nothing`, i.e. if no checks are implemented, the
+assumption is to be optimistic.
+"""
+function check_size(M::Manifold, p)
+    n = size(p)
+    m = representation_size(M)
+    if length(n) != length(m)
+        return DomainError(n, "The point $(p) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).")
+    end
+    if any(n != m)
+        return DomainError("The point $(p) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).")
+    end
+end
+function check_size(M::Manifold,p,X)
+    mse = check_size(M,p)
+    mse === nothing || return mse
+    n = size(X)
+    m = representation_size(M)
+    if length(n) != length(m)
+        return DomainError(n, "The tangent vector $(X) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).")
+    end
+    if any(n != m)
+        return DomainError("The tangent vector $(X) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).")
+    end
+end
+
+"""
     distance(M::Manifold, p, q)
 
 Shortest distance between the points `p` and `q` on the [`Manifold`](@ref) `M`.
@@ -820,6 +854,7 @@ export allocate,
     base_manifold,
     check_manifold_point,
     check_tangent_vector,
+    check_size,
     distance,
     exp,
     exp!,

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -697,7 +697,7 @@ Lie algebra is perfomed, too.
 See also: [`EmbeddedManifold`](@ref), [`embed`](@ref embed(M::Manifold, p, X))
 """
 function project(M::Manifold, p, X)
-    Y = allocate_result(M, project, X, p)
+    Y = allocate_result(M, project, p, X)
     project!(M, Y, p, X)
     return Y
 end

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -340,6 +340,8 @@ the tangent spaces of the embedded base points.
 See also: [`EmbeddedManifold`](@ref), [`project`](@ref project(M::Manifold, p, X))
 """
 function embed(M::Manifold, p, X)
+    # Note that the order is switched,
+    # since the allocation by default takes the type of the first.
     Y = allocate_result(M, embed, X, p)
     embed!(M, Y, p, X)
     return Y
@@ -697,7 +699,9 @@ Lie algebra is perfomed, too.
 See also: [`EmbeddedManifold`](@ref), [`embed`](@ref embed(M::Manifold, p, X))
 """
 function project(M::Manifold, p, X)
-    Y = allocate_result(M, project, p, X)
+    # Note that the order is switched,
+    # since the allocation by default takes the type of the first.
+    Y = allocate_result(M, project, X, p)
     project!(M, Y, p, X)
     return Y
 end

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -254,12 +254,15 @@ function check_size(M::Manifold, p)
     m = representation_size(M)
     if length(n) != length(m)
         return DomainError(
-            n,
-            "The point $(p) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).",
+            length(n),
+            "The point $(p) can not belong to the manifold $(M), since its size $(n) is not equal to the manifolds representation size ($(m)).",
         )
     end
-    if any(n != m)
-        return DomainError("The point $(p) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).")
+    if n != m
+        return DomainError(
+            n,
+            "The point $(p) can not belong to the manifold $(M), since its size $(n) is not equal to the manifolds representation size ($(m)).",
+        )
     end
 end
 function check_size(M::Manifold, p, X)
@@ -269,12 +272,15 @@ function check_size(M::Manifold, p, X)
     m = representation_size(M)
     if length(n) != length(m)
         return DomainError(
-            n,
-            "The tangent vector $(X) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).",
+            length(n),
+            "The tangent vector $(X) can not belong to the manifold $(M), since its size $(n) is not equal to the manifolds representation size ($(m)).",
         )
     end
-    if any(n != m)
-        return DomainError("The tangent vector $(X) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).")
+    if n != m
+        return DomainError(
+            n,
+            "The tangent vector $(X) can not belong to the manifold $(M), since its size $(n) is not equal to the manifodls representation size ($(m)).",
+        )
     end
 end
 

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -253,19 +253,25 @@ function check_size(M::Manifold, p)
     n = size(p)
     m = representation_size(M)
     if length(n) != length(m)
-        return DomainError(n, "The point $(p) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).")
+        return DomainError(
+            n,
+            "The point $(p) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).",
+        )
     end
     if any(n != m)
         return DomainError("The point $(p) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).")
     end
 end
-function check_size(M::Manifold,p,X)
-    mse = check_size(M,p)
+function check_size(M::Manifold, p, X)
+    mse = check_size(M, p)
     mse === nothing || return mse
     n = size(X)
     m = representation_size(M)
     if length(n) != length(m)
-        return DomainError(n, "The tangent vector $(X) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).")
+        return DomainError(
+            n,
+            "The tangent vector $(X) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).",
+        )
     end
     if any(n != m)
         return DomainError("The tangent vector $(X) can not belong to the manifold $(M), since its size $(n) does not fit the required representation size ($(m)).")

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -66,8 +66,10 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         # Check fallbacks to check embed->check_manifoldpoint Defaults
         @test_throws DomainError is_manifold_point(M, [1, 0, 0], true)
         @test_throws DomainError is_manifold_point(M, [1 0], true)
+        @test is_manifold_point(M, [1 0 0], true)
         @test_throws DomainError is_tangent_vector(M, [1 0 0], [1], true)
         @test_throws DomainError is_tangent_vector(M, [1 0 0], [0 0 0 0], true)
+        @test is_tangent_vector(M, [1 0 0], [1 0 1], true)
         p = [1.0 1.0 0.0]
         q = [1.0 0.0 0.0]
         X = q - p

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -108,8 +108,9 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         @testset "Default Isometric Embedding Fallback Error Tests" begin
             M = NotImplementedEmbeddedManifold()
             A = zeros(2)
-            @test_throws ErrorException check_manifold_point(M, [1, 2])
-            @test_throws ErrorException check_tangent_vector(M, [1, 2], [3, 4])
+            # without any extra tests just the embedding is asked
+            @test check_manifold_point(M, [1, 2]) === nothing
+            @test check_tangent_vector(M, [1, 2], [3, 4]) === nothing
             @test norm(M, [1, 2], [2, 3]) ≈ sqrt(13)
             @test inner(M, [1, 2], [2, 3], [2, 3]) ≈ 13
             @test_throws ErrorException manifold_dimension(M)

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -1,25 +1,16 @@
-
 struct PlaneManifold <: AbstractEmbeddedManifold{ℝ,TransparentIsometricEmbedding} end
 
-ManifoldsBase.get_embedding(::PlaneManifold) = ManifoldsBase.DefaultManifold(1, 3)
+ManifoldsBase.decorated_manifold(::PlaneManifold) = ManifoldsBase.DefaultManifold(1, 3)
 ManifoldsBase.base_manifold(::PlaneManifold) = ManifoldsBase.DefaultManifold(2)
 
-function ManifoldsBase.embed!(::PlaneManifold, q, p)
-    q[1:2] = p
-    q[3] = 0
-    return q
-end
-function ManifoldsBase.embed!(::PlaneManifold, Y, p, X)
-    Y[1:2] = X
-    Y[3] = 0
-    return X
-end
-ManifoldsBase.project!(::PlaneManifold, q, p) = (q .= [p[1], p[2]])
-ManifoldsBase.project!(::PlaneManifold, Y, p, X) = (Y .= [X[1], X[2]])
+ManifoldsBase.embed!(::PlaneManifold, q, p) = copyto!(q, p)
+ManifoldsBase.embed!(::PlaneManifold, Y, p, X) = copyto!(Y, X)
+ManifoldsBase.project!(::PlaneManifold, q, p) = (q .= [p[1] p[2] 0.0])
+ManifoldsBase.project!(::PlaneManifold, Y, p, X) = (Y .= [X[1] X[2] 0.0])
 
 struct AnotherPlaneManifold <: AbstractEmbeddedManifold{ℝ,DefaultIsometricEmbeddingType} end
 
-ManifoldsBase.get_embedding(::AnotherPlaneManifold) = ManifoldsBase.DefaultManifold(3)
+ManifoldsBase.decorated_manifold(::AnotherPlaneManifold) = ManifoldsBase.DefaultManifold(3)
 ManifoldsBase.base_manifold(::AnotherPlaneManifold) = ManifoldsBase.DefaultManifold(2)
 
 function ManifoldsBase.embed!(::AnotherPlaneManifold, q, p)
@@ -41,7 +32,7 @@ end
 
 struct NotImplementedEmbeddedManifold <:
        AbstractEmbeddedManifold{ℝ,TransparentIsometricEmbedding} end
-function ManifoldsBase.get_embedding(::NotImplementedEmbeddedManifold)
+function ManifoldsBase.decorated_manifold(::NotImplementedEmbeddedManifold)
     return ManifoldsBase.DefaultManifold(2)
 end
 function ManifoldsBase.base_manifold(::NotImplementedEmbeddedManifold)
@@ -62,7 +53,7 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         @test repr(M) ==
               "EmbeddedManifold($(sprint(show, M.manifold)), $(sprint(show, M.embedding)), TransparentIsometricEmbedding())"
         @test base_manifold(M) == ManifoldsBase.DefaultManifold(2)
-        @test ManifoldsBase.get_embedding(M) == ManifoldsBase.DefaultManifold(3)
+        @test ManifoldsBase.decorated_manifold(M) == ManifoldsBase.DefaultManifold(3)
         @test ManifoldsBase.default_embedding_dispatch(M) === Val{false}()
         @test ManifoldsBase.default_decorator_dispatch(M) ===
               ManifoldsBase.default_embedding_dispatch(M)
@@ -74,28 +65,28 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         @test get_embedding(M) == ManifoldsBase.DefaultManifold(1, 3)
         # Check fallbacks to check embed->check_manifoldpoint Defaults
         @test_throws DomainError is_manifold_point(M, [1, 0, 0], true)
-        @test is_manifold_point(M, [1, 0], true)
-        @test_throws DomainError is_manifold_point(M, [1 0 0], true)
+        @test_throws DomainError is_manifold_point(M, [1 0], true)
+        @test is_manifold_point(M, [1 0 0], true)
         @test_throws DomainError is_tangent_vector(M, [1 0 0], [1], true)
-        @test is_tangent_vector(M, [1, 0], [0, 2], true)
-        @test_throws DomainError is_tangent_vector(M, [1 0 0], [1 0 1], true)
-        p = [1.0, 0.0]
-        q = [1.0, 2.0]
+        @test_throws DomainError is_tangent_vector(M, [1 0 0], [0 0 0 0], true)
+        @test is_tangent_vector(M, [1 0 0], [1 0 1], true)
+        p = [1.0 1.0 0.0]
+        q = [1.0 0.0 0.0]
         X = q - p
         @test check_size(M, p) === nothing
         @test check_size(M, p, X) === nothing
-        @test check_size(M, [1 2 2]) isa DomainError
-        @test check_size(M, [1, 2, 3]) isa DomainError
-        @test check_size(M, p, [1 2 4]) isa DomainError
-        @test check_size(M, p, [1, 3, 4]) isa DomainError
-        @test embed(M, p) == vcat(p, 0.0)'
-        pE = similar(p, (1, 3))
+        @test check_size(M, [1, 2]) isa DomainError
+        @test check_size(M, [1 2 3 4]) isa DomainError
+        @test check_size(M, p, [1, 2]) isa DomainError
+        @test check_size(M, p, [1 2 3 4]) isa DomainError
+        @test embed(M, p) == p
+        pE = similar(p)
         embed!(M, pE, p)
-        @test pE == vcat(p, 0.0)'
+        @test pE == p
         P = [1.0 1.0 2.0]
-        Q = similar(P, (2,))
+        Q = similar(P)
         @test project!(M, Q, P) == project!(M, Q, P)
-        @test project!(M, Q, P) == [1.0, 1.0]
+        @test project!(M, Q, P) == [1.0 1.0 0.0]
 
         @test log(M, p, q) == q - p
         Y = similar(p)
@@ -150,9 +141,9 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
             @test_throws ErrorException log(M2, [1, 2], [2, 3])
             @test_throws ErrorException log!(M2, A, [1, 2], [2, 3])
             @test_throws ErrorException manifold_dimension(M2)
-            @test_throws StackOverflowError project(M2, [1, 2])
+            @test_throws ErrorException project(M2, [1, 2])
             @test_throws ErrorException project!(M2, A, [1, 2])
-            @test_throws StackOverflowError project(M2, [1, 2], [2, 3])
+            @test_throws ErrorException project(M2, [1, 2], [2, 3])
             @test_throws ErrorException project!(M2, A, [1, 2], [2, 3])
             @test_throws ErrorException vector_transport_along(M2, [1, 2], [2, 3], [[1, 2]])
             @test_throws ErrorException vector_transport_along(
@@ -205,17 +196,13 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         for f in [mid_point, mid_point!]
             @test ManifoldsBase.decorator_transparent_dispatch(f, AM) === Val(:parent)
         end
-        for f in [exp!, inner, embed!]
+        for f in [check_manifold_point, check_tangent_vector, exp!, inner, embed!]
             @test ManifoldsBase.decorator_transparent_dispatch(f, AM) ===
                   Val(:intransparent)
         end
         for f in [log!, norm, manifold_dimension, project!]
             @test ManifoldsBase.decorator_transparent_dispatch(f, AM) ===
                   Val(:intransparent)
-        end
-        for f in [check_manifold_point, check_tangent_vector]
-            @test ManifoldsBase.decorator_transparent_dispatch(f, AM) ===
-                  Val(:transparent)
         end
         @test ManifoldsBase.decorator_transparent_dispatch(vector_transport_along!, AM) ===
               Val(:intransparent)

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -51,17 +51,17 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
             ManifoldsBase.DefaultManifold(3),
         )
         @test repr(M) ==
-              "EmbeddedManifold($(sprint(show, M.manifold)), $(sprint(show, M.embedding)), TransparentIsometricEmbedding())"
+              "EmbeddedManifold($(sprint(show, M.manifold)), $(sprint(show, M.embedding)))"
         @test base_manifold(M) == ManifoldsBase.DefaultManifold(2)
         @test ManifoldsBase.decorated_manifold(M) == ManifoldsBase.DefaultManifold(3)
-        @test ManifoldsBase.default_embedding_dispatch(M) === Val{false}()
+        @test ManifoldsBase.default_embedding_dispatch(M) === Val(true)
         @test ManifoldsBase.default_decorator_dispatch(M) ===
               ManifoldsBase.default_embedding_dispatch(M)
     end
     @testset "PlaneManifold" begin
         M = PlaneManifold()
         @test repr(M) == "PlaneManifold()"
-        @test ManifoldsBase.default_decorator_dispatch(M) === Val{false}()
+        @test ManifoldsBase.default_decorator_dispatch(M) === Val(false)
         @test get_embedding(M) == ManifoldsBase.DefaultManifold(1, 3)
         # Check fallbacks to check embed->check_manifoldpoint Defaults
         @test_throws DomainError is_manifold_point(M, [1, 0, 0], true)

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -54,9 +54,7 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
               "EmbeddedManifold($(sprint(show, M.manifold)), $(sprint(show, M.embedding)))"
         @test base_manifold(M) == ManifoldsBase.DefaultManifold(2)
         @test ManifoldsBase.decorated_manifold(M) == ManifoldsBase.DefaultManifold(3)
-        @test ManifoldsBase.default_embedding_dispatch(M) === Val(true)
-        @test ManifoldsBase.default_decorator_dispatch(M) ===
-              ManifoldsBase.default_embedding_dispatch(M)
+        @test ManifoldsBase.default_decorator_dispatch(M) === Val(true)
     end
     @testset "PlaneManifold" begin
         M = PlaneManifold()

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -53,9 +53,11 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         @test repr(M) ==
               "EmbeddedManifold($(sprint(show, M.manifold)), $(sprint(show, M.embedding)))"
         @test base_manifold(M) == ManifoldsBase.DefaultManifold(2)
+        @test get_embedding(M) == ManifoldsBase.DefaultManifold(3)
         @test ManifoldsBase.decorated_manifold(M) == ManifoldsBase.DefaultManifold(3)
         @test ManifoldsBase.default_decorator_dispatch(M) === Val(true)
     end
+
     @testset "PlaneManifold" begin
         M = PlaneManifold()
         @test repr(M) == "PlaneManifold()"
@@ -177,6 +179,7 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
             @test_throws ErrorException embed(M3, [1, 2])
         end
     end
+
     @testset "EmbeddedManifold decorator dispatch" begin
         TM = NotImplementedEmbeddedManifold() # transparently iso
         IM = NotImplementedEmbeddedManifold2() # iso

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -62,6 +62,7 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         M = PlaneManifold()
         @test repr(M) == "PlaneManifold()"
         @test ManifoldsBase.default_decorator_dispatch(M) === Val(false)
+        @test ManifoldsBase.default_embedding_dispatch(M) === Val(false)
         @test get_embedding(M) == ManifoldsBase.DefaultManifold(1, 3)
         # Check fallbacks to check embed->check_manifoldpoint Defaults
         @test_throws DomainError is_manifold_point(M, [1, 0, 0], true)

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -64,9 +64,10 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         @test ManifoldsBase.default_decorator_dispatch(M) === Val{false}()
         @test get_embedding(M) == ManifoldsBase.DefaultManifold(1, 3)
         # Check fallbacks to check embed->check_manifoldpoint Defaults
-        @test is_manifold_point(M, [1, 0], true)
-        @test is_tangent_vector(M, [1, 0], [1, 0, 0], true)
-        @test is_tangent_vector(M, [1, 0, 0], [0, 0], true)
+        @test_throws DomainError is_manifold_point(M, [1, 0, 0], true)
+        @test_throws DomainError is_manifold_point(M, [1 0], true)
+        @test_throws DomainError is_tangent_vector(M, [1 0 0], [1], true)
+        @test_throws DomainError is_tangent_vector(M, [1 0 0], [0 0 0 0], true)
         p = [1.0 1.0 0.0]
         q = [1.0 0.0 0.0]
         X = q - p

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -73,6 +73,12 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         p = [1.0 1.0 0.0]
         q = [1.0 0.0 0.0]
         X = q - p
+        @test check_size(M, p) === nothing
+        @test check_size(M, p, X) === nothing
+        @test check_size(M, [1, 2]) isa DomainError
+        @test check_size(M, [1 2 3 4]) isa DomainError
+        @test check_size(M, p, [1, 2]) isa DomainError
+        @test check_size(M, p, [1 2 3 4]) isa DomainError
         @test embed(M, p) == p
         pE = similar(p)
         embed!(M, pE, p)


### PR DESCRIPTION
I was using a “feature”, where on any manifold the allocation was performed using the size of the point instead of the representation size. This small PR makes this more rigorous and introduces a `check_size` for points and vectors, that might even simplify tests for certain manifolds (by a few lines).