### PR TITLE
Correct allocations for explicit embeddings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.9.3"
+version = "0.9.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -251,11 +251,7 @@ function decorator_transparent_dispatch(
 )
     return Val(:parent)
 end
-function decorator_transparent_dispatch(
-    ::typeof(embed),
-    ::EmbeddedManifold,
-    args...,
-)
+function decorator_transparent_dispatch(::typeof(embed), ::EmbeddedManifold, args...)
     return Val(:intransparent)
 end
 function decorator_transparent_dispatch(
@@ -462,6 +458,9 @@ function decorator_transparent_dispatch(
     args...,
 ) where {𝔽}
     return Val(:transparent)
+end
+function decorator_transparent_dispatch(::typeof(project), ::EmbeddedManifold, args...)
+    return Val(:intransparent)
 end
 function decorator_transparent_dispatch(
     ::typeof(retract),

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -100,6 +100,17 @@ function allocate_result(M::AbstractEmbeddedManifold, f::typeof(project), x...)
     return allocate(x[1], T, representation_size(base_manifold(M)))
 end
 
+function allocate_result(M::EmbeddedManifold, f::typeof(embed), x...)
+    T = allocate_result_type(M, f, x)
+    return allocate(x[1], T, representation_size(get_embedding(M)))
+end
+
+function allocate_result(M::EmbeddedManifold, f::typeof(project), x...)
+    T = allocate_result_type(M, f, x)
+    return allocate(x[1], T, representation_size(base_manifold(M)))
+end
+
+
 """
     base_manifold(M::AbstractEmbeddedManifold, d::Val{N} = Val(-1))
 
@@ -165,6 +176,13 @@ end
 
 decorated_manifold(M::EmbeddedManifold) = M.embedding
 
+function embed(M::EmbeddedManifold, p)
+    q = allocate_result(M, embed, p)
+    embed!(M, q, p)
+    return q
+end
+
+
 """
     get_embedding(M::AbstractEmbeddedManifold)
 
@@ -185,6 +203,12 @@ get_embedding(::EmbeddedManifold)
 
 function get_embedding(M::EmbeddedManifold)
     return M.embedding
+end
+
+function project(M::EmbeddedManifold, p)
+    q = allocate_result(M, project, p)
+    project!(M, q, p)
+    return q
 end
 
 function show(io::IO, M::EmbeddedManifold{𝔽,MT,NT}) where {𝔽,MT<:Manifold{𝔽},NT<:Manifold}
@@ -226,6 +250,13 @@ function decorator_transparent_dispatch(
     args...,
 )
     return Val(:parent)
+end
+function decorator_transparent_dispatch(
+    ::typeof(embed),
+    ::EmbeddedManifold,
+    args...,
+)
+    return Val(:intransparent)
 end
 function decorator_transparent_dispatch(
     ::typeof(embed!),

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -323,5 +323,8 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         @test_throws DomainError embed!(O, zeros(3, 3), zeros(4, 4))
         @test_throws DomainError project!(O, zeros(3, 3, 5), zeros(3, 3))
         @test_throws DomainError project!(O, zeros(4, 4), zeros(3, 3))
+        for f in [embed, project]
+            @test ManifoldsBase.decorator_transparent_dispatch(f, O) === Val(:intransparent)
+        end
     end
 end


### PR DESCRIPTION
I somehow must have missed this, I had this in place in the last PR but deleted it again, since it was not covered by tests – in fact said tests were just missing, and the implementation is necessary for the embedded manifold to allocate the right sizes. This hence adds the tests and fixes the allocation issue;
reason is, that our decorator pattern never passes on to the embedding (since it decorates `M.manifold`).