### PR TITLE
Fixes the case of nested manifolds to do a single getindex if we access an element

### DIFF
--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -495,6 +495,15 @@ Base.@propagate_inbounds function Base.getindex(
 )
     return collect(get_component(M, p, I...))
 end
+Base.@propagate_inbounds function Base.getindex(
+    p::AbstractArray,
+    M::PowerManifoldNested,
+    I::Integer...,
+)
+    # for a single element of the nested Power manifold, return just an element
+    # otherwise do just as for the default case above.
+    return ndims(p) == length(I) ? p[I...] : collect(get_component(M, p, I...))
+end
 
 @doc raw"""
     injectivity_radius(M::AbstractPowerManifold[, p])


### PR DESCRIPTION
This PR fixes the following example (of manifolds)

```julia
using Manifolds
a = zeros(3)
N = PowerManifold(Circle(), NestedPowerRepresentation(), 3)
a[N,1]
```
which previously returned a view to a `0`-dimensional array (i.e. `a[N,1][]` could access the number again).

While I think this fix is nice, there is a point I am not sure about:

If `represenation_size(M)` is not `()` the single access to the one element can (and should?) better still be a `view` I think? Or is it for the nested case, that the inner “refrence” is returned anyways? Then the fix here should be enough.