### PR TITLE
introduce copyto! for points and tangent vectors.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.10.4"
+version = "0.10.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -298,6 +298,25 @@ function check_size(M::Manifold, p, X)
     end
 end
 
+@doc raw"""
+    copyto!(M::Manifold, q, p)
+
+Copy the value(s) from `p` to `q`, where both are points on the [`Manifold`](@ref) `M`.
+This function defaults to calling `copyto!(q, p)`, but it might be useful to overwrite the
+function at the level, where also information from `M` can be accessed.
+"""
+copyto!(::Manifold, q, p) = copyto!(q, p)
+
+@doc raw"""
+    copyto!(M::Manifold, Y, X)
+
+Copy the value(s) from `X` to `Y`, where both are tangent vector from the tangent space at
+`p` on the [`Manifold`](@ref) `M`.
+This function defaults to calling `copyto!(Y, X)`, but it might be useful to overwrite the
+function at the level, where also information from `p` and `M` can be accessed.
+"""
+copyto!(::Manifold, Y, p, X) = copyto!(Y, X)
+
 """
     distance(M::Manifold, p, q)
 

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -292,6 +292,38 @@ function check_tangent_vector(
     return nothing
 end
 
+@doc raw"""
+    copyto!(M::AbstractPowerManifold{𝔽,<:Manifold{𝔽},NestedPowerRepresentation}, q, p)
+
+copy the values elementwise, i.e. call `copyto!(M.manifold, b, a)` for all elements `a`and
+`b` of `p` and `q`, respectively.
+"""
+function copyto!(M::NestedPowerRepresentation, q, p)
+    rep_size = representation_size(M.manifold)
+    for i in get_iterator(M)
+        copyto!(M.manifold, _write(M, rep_size, q, i), _read(M, rep_size, p, i))
+    end
+    return q
+end
+
+@doc raw"""
+    copyto!(M::AbstractPowerManifold{𝔽,<:Manifold{𝔽},NestedPowerRepresentation}, Y, p, X)
+
+copy the values elementwise, i.e. call `copyto!(M.manifold, B, a, A)` for all elements
+`A`, `a` and `B` of `X`, `p`, and `Y`, respectively.
+"""
+function copyto!(M::NestedPowerRepresentation, Y, p, X)
+    rep_size = representation_size(M.manifold)
+    for i in get_iterator(M)
+        copyto!(
+            M.manifold,
+            _write(M, rep_size, Y, i),
+            _read(M, rep_size, p, i),
+            _read(M, rep_size, X, i),
+        )
+    end
+    return Y
+end
 
 @doc raw"""
     distance(M::AbstractPowerManifold, p, q)
@@ -968,12 +1000,12 @@ end
     return _write(M, rep_size, x, (i,))
 end
 
-@inline function _write(M::PowerManifoldNested, rep_size::Tuple, x::AbstractArray, i::Tuple)
+@inline function _write(::PowerManifoldNested, rep_size::Tuple, x::AbstractArray, i::Tuple)
     return view(x[i...], rep_size_to_colons(rep_size)...)
 end
 @inline function _write(
-    M::PowerManifoldNested,
-    rep_size::Tuple{},
+    ::PowerManifoldNested,
+    ::Tuple{},
     x::AbstractArray,
     i::Tuple,
 )

--- a/src/ValidationManifold.jl
+++ b/src/ValidationManifold.jl
@@ -107,16 +107,16 @@ function convert(::Type{ValidationTVector{V}}, X::V) where {V<:AbstractArray{<:N
     return ValidationTVector{V}(X)
 end
 
-function copyto!(p::ValidationMPoint, q::ValidationMPoint)
-    copyto!(p.value, q.value)
+function copyto!(M::ValidationManifold, p::ValidationMPoint, q::ValidationMPoint)
+    copyto!(M.manifold, p.value, q.value)
     return p
 end
-function copyto!(p::ValidationCoTVector, q::ValidationCoTVector)
-    copyto!(p.value, q.value)
+function copyto!(M::ValidationManifold, p::ValidationCoTVector, q::ValidationCoTVector)
+    copyto!(M.manifold, p.value, q.value)
     return p
 end
-function copyto!(Y::ValidationTVector, X::ValidationTVector)
-    copyto!(Y.value, X.value)
+function copyto!(M::ValidationManifold, Y::ValidationTVector, X::ValidationTVector)
+    copyto!(M.manifold, Y.value, X.value)
     return Y
 end
 

--- a/test/validation_manifold.jl
+++ b/test/validation_manifold.jl
@@ -55,7 +55,7 @@ end
             @test similar(p, Float32) isa T
             @test number_eltype(similar(p, Float32)) == Float32
             q = allocate(p)
-            copyto!(q, p)
+            copyto!(A, q, p)
             @test isapprox(A, q, p)
             @test ManifoldsBase.array_value(p) == x
             @test ManifoldsBase.array_value(x) == x


### PR DESCRIPTION
As discussed in JuliaManifolds/Manopt.jl#78 it might be beneficial to have a `copyto!` already on the manifold level.
This PR introduces that. There are a few points to check/todo.

* [ ] it it reasonable to introduce transparency? For the validation manifold, the copyto! just solves this, but for group and metric? Sure it would also just be one line unpacking the manifold, I think.
* [ ] Technically this is breaking, since the interface for the copyto! for the ValidationManifold changed – but did we use than anywhere?
* [ ] There seems to be an ambiguity in some code that I did not tough (for 1.7 this is anticipated but I also get that on 1.6 concerning the `getindex`. Should this be resolved here? The CI is running on 1.5 still anyways.
* [ ] Test coverage