### PR TITLE
removes passing on the last parameter for get_vector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.10.5"
+version = "0.10.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -218,10 +218,7 @@ function allocate_result(
     )
 end
 function allocate_result(M::PowerManifoldNested, f::typeof(get_vector), p, X)
-    return [
-        allocate_result(M.manifold, f, _access_nested(p, i)) for
-        i in get_iterator(M)
-    ]
+    return [allocate_result(M.manifold, f, _access_nested(p, i)) for i in get_iterator(M)]
 end
 function allocation_promotion_function(M::AbstractPowerManifold, f, args::Tuple)
     return allocation_promotion_function(M.manifold, f, args)

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -219,7 +219,7 @@ function allocate_result(
 end
 function allocate_result(M::PowerManifoldNested, f::typeof(get_vector), p, X)
     return [
-        allocate_result(M.manifold, f, _access_nested(p, i), _access_nested(X, i)) for
+        allocate_result(M.manifold, f, _access_nested(p, i)) for
         i in get_iterator(M)
     ]
 end


### PR DESCRIPTION
Somehow I added this because I thought this was missing, but it seems to break `vee` and `hat` for power manifolds over in `Manifolds.jl`.
So this undoes the change.