### PR TITLE
Ensure norm succeeds on numerical errors in inner(...)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.10.6"
+version = "0.10.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -669,7 +669,7 @@ end
 Compute the norm of tangent vector `X` at point `p` from a [`Manifold`](@ref) `M`.
 By default this is computed using [`inner`](@ref).
 """
-norm(M::Manifold, p, X) = sqrt(real(inner(M, p, X, X)))
+norm(M::Manifold, p, X) = sqrt(max(real(inner(M, p, X, X)), 0))
 
 """
     number_eltype(x)


### PR DESCRIPTION
Due to numerical errors the inner product can sometimes return an infinitesimal negative number (e.g. -1e-26). This negative number causes the sqrt to fail with a domain error

This fix ensures that the result of the inner product of X and X is always greater than or equal to zero (which it should be by definition)