### PR TITLE
introduces getindex for decorators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.11.1"
+version = "0.11.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/DecoratorManifold.jl
+++ b/src/DecoratorManifold.jl
@@ -718,3 +718,14 @@ decorated_manifold(M::AbstractManifold) = M.manifold
 
 @decorator_transparent_signature zero_vector(M::AbstractDecoratorManifold, p)
 @decorator_transparent_signature zero_vector!(M::AbstractDecoratorManifold, X, p)
+
+#
+# Manually patch getindex not using the whole machinery
+#
+Base.@propagate_inbounds function Base.getindex(
+    p::AbstractArray,
+    M::AbstractDecoratorManifold,
+    I::Union{Integer,Colon,AbstractVector}...,
+)
+    return getindex(p, decorated_manifold(M), I...)
+end

--- a/test/power.jl
+++ b/test/power.jl
@@ -3,6 +3,10 @@ using ManifoldsBase
 using ManifoldsBase: AbstractNumbers, ℝ, ℂ
 
 struct DummyPowerRepresentation <: AbstractPowerRepresentation end
+struct DummyDecorator{TM<:AbstractManifold{ManifoldsBase.ℝ}} <:
+       AbstractDecoratorManifold{ManifoldsBase.ℝ}
+    manifold::TM
+end
 
 @testset "Power AbstractManifold" begin
     M = ManifoldsBase.DefaultManifold(3)
@@ -130,10 +134,6 @@ struct DummyPowerRepresentation <: AbstractPowerRepresentation end
         @test zero_vector(N, p) == zero(p)
     end
     @testset "Decorator passthrough for getindex" begin
-        struct DummyDecorator{TM<:AbstractManifold{ManifoldsBase.ℝ}} <:
-               AbstractDecoratorManifold{ManifoldsBase.ℝ}
-            manifold::TM
-        end
         M = ManifoldsBase.DefaultManifold()
         N = PowerManifold(M, NestedPowerRepresentation(), 3)
         p = [1.0, 2.0, 3.0]

--- a/test/power.jl
+++ b/test/power.jl
@@ -129,4 +129,15 @@ struct DummyPowerRepresentation <: AbstractPowerRepresentation end
         @test p[N, 1] == 1.0
         @test zero_vector(N, p) == zero(p)
     end
+    @testset "Decorator passthrough for getindex" begin
+        struct DummyDecorator{TM<:AbstractManifold{ManifoldsBase.ℝ}} <:
+               AbstractDecoratorManifold{ManifoldsBase.ℝ}
+            manifold::TM
+        end
+        M = ManifoldsBase.DefaultManifold()
+        N = PowerManifold(M, NestedPowerRepresentation(), 3)
+        p = [1.0, 2.0, 3.0]
+        DN = DummyDecorator(N)
+        @test p[DN, 1] == p[N, 1]
+    end
 end


### PR DESCRIPTION
Makes `getindex` transparent for any decorator (by using the same technique as `base_manifold`, i.e. without the full decorator machinery. Fixes JuliaManifolds/Manifolds.jl#364