### PR TITLE
Introduce different decorator types

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.11.4"
+version = "0.12.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![](https://img.shields.io/badge/docs-dev-blue.svg)](https://juliamanifolds.github.io/Manifolds.jl/latest/interface.html)
 [![Build Status](https://travis-ci.org/JuliaManifolds/ManifoldsBase.jl.svg?branch=master)](https://travis-ci.org/JuliaManifolds/ManifoldsBase.jl/)
 [![codecov.io](http://codecov.io/github/JuliaManifolds/ManifoldsBase.jl/coverage.svg?branch=master)](https://codecov.io/gh/JuliaManifolds/ManifoldsBase.jl/)
+[![arXiv](https://img.shields.io/badge/arXiv%20CS.MS-2106.08777-blue.svg)](https://arxiv.org/abs/2106.08777)
 
 Basic interface for manifolds in Julia.
 
@@ -57,3 +58,16 @@ by type.
 
 This adds a semantic layer to the interface, and the default implementation of
 `ValidationManifold` adds checks to all inputs and outputs of typed data.
+
+## Citation
+If you use `ManifoldsBase.jl` in your work, please cite the following
+
+```biblatex
+@online{2106.08777,
+Author = {Seth D. Axen and Mateusz Baran and Ronny Bergmann and Krzysztof Rzecki},
+Title = {Manifolds.jl: An Extensible Julia Framework for Data Analysis on Manifolds},
+Year = {2021},
+Eprint = {2106.08777},
+Eprinttype = {arXiv},
+}
+```

--- a/src/DecoratorManifold.jl
+++ b/src/DecoratorManifold.jl
@@ -788,7 +788,7 @@ DEFAULT_PARENT_FUNCTIONS = [
     vector_transport_to,
 ]
 
-for f in PARENT_FUNCTIONS
+for f in DEFAULT_PARENT_FUNCTIONS
     eval(
         quote
             function decorator_transparent_dispatch(

--- a/src/DecoratorManifold.jl
+++ b/src/DecoratorManifold.jl
@@ -774,7 +774,7 @@ Base.@propagate_inbounds function Base.getindex(
     return getindex(p, decorated_manifold(M), I...)
 end
 
-PARENT_FUNCTIONS = [
+DEFAULT_PARENT_FUNCTIONS = [
     distance,
     exp,
     inner,

--- a/src/DecoratorManifold.jl
+++ b/src/DecoratorManifold.jl
@@ -93,8 +93,6 @@ Note that for a function `f` and it's mutating variant `f!`
 """
 abstract type AbstractDecoratorType end
 
-
-
 """
     DefaultDecoratorType <: AbstractDecoratorType
 
@@ -128,7 +126,7 @@ Transparency of functions with respect to decorators can be specified using the 
 There are currently three modes given a new `AbstractDecoratorManifold` `M`
 * `:intransparent` – this function has to be implmented for the new manifold `M`
 * `:transparent` – this function is transparent, in the sense that the function is invoked
-  on the decorated `M.manifold`
+  on the decorated `M.manifold`. This is the default, when introducing a function or signature.
 * `:parent` specifies that (unless implemented) for this function, the classical inheritance
   is issued, i.e. the function is invoked on `M`s supertype.
 """
@@ -775,10 +773,6 @@ Base.@propagate_inbounds function Base.getindex(
 ) where {𝔽}
     return getindex(p, decorated_manifold(M), I...)
 end
-
-#
-# Dispatch rules
-#
 
 PARENT_FUNCTIONS = [
     distance,

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -1,9 +1,9 @@
 """
-    AbstractEmbeddingType
+    AbstractEmbeddingType <: AbstractDecoratorType
 
 A type used to specify properties of an [`AbstractEmbeddedManifold`](@ref).
 """
-abstract type AbstractEmbeddingType end
+abstract type AbstractEmbeddingType <: AbstractDecoratorType end
 
 """
     AbstractEmbeddedManifold{𝔽,T<:AbstractEmbeddingType,𝔽} <: AbstractDecoratorManifold{𝔽}
@@ -28,7 +28,7 @@ Technically this is realised by making the [`AbstractEmbeddedManifold`](@ref) is
 for the [`AbstractManifold`](@ref)s that are subtypes.
 """
 abstract type AbstractEmbeddedManifold{𝔽,T<:AbstractEmbeddingType} <:
-              AbstractDecoratorManifold{𝔽} end
+              AbstractDecoratorManifold{𝔽,T} end
 
 """
     DefaultEmbeddingType <: AbstractEmbeddingType
@@ -92,7 +92,7 @@ Generate the `EmbeddedManifold` of the [`AbstractManifold`](@ref) `M` into the
 [`AbstractManifold`](@ref) `N`.
 """
 struct EmbeddedManifold{𝔽,MT<:AbstractManifold{𝔽},NT<:AbstractManifold} <:
-       AbstractDecoratorManifold{𝔽}
+       AbstractDecoratorManifold{𝔽,AbstractDecoratorType}
     manifold::MT
     embedding::NT
 end
@@ -127,14 +127,14 @@ representing the embedding, the base_manifold is the manifold itself in the sens
 detemining e.g. the [`is_default_metric`](@ref) does not fall back to check with
 the embedding but with the manifold itself. For this abstract case, just `M` is returned.
 """
-base_manifold(M::AbstractEmbeddedManifold, d::Val{N} = Val(-1)) where {N} = M
+base_manifold(M::AbstractEmbeddedManifold, ::Val{N} = Val(-1)) where {N} = M
 """
     base_manifold(M::EmbeddedManifold, d::Val{N} = Val(-1))
 
 Return the base manifold of `M` that is enhanced with its embedding. For this specific
 type the internally stored enhanced manifold `M.manifold` is returned.
 """
-base_manifold(M::EmbeddedManifold, d::Val{N} = Val(-1)) where {N} = M.manifold
+base_manifold(M::EmbeddedManifold, ::Val{N} = Val(-1)) where {N} = M.manifold
 
 
 """
@@ -228,7 +228,7 @@ This is used by the [`AbstractDecoratorManifold`](@ref) within
 [`default_decorator_dispatch`](@ref).
 By default this is set to `Val(false)`.
 """
-default_embedding_dispatch(M::AbstractEmbeddedManifold) = Val(false)
+default_embedding_dispatch(::AbstractEmbeddedManifold) = Val(false)
 
 function decorator_transparent_dispatch(
     ::typeof(check_point),
@@ -243,13 +243,6 @@ function decorator_transparent_dispatch(
     args...,
 )
     return Val(:intransparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(distance),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
 end
 function decorator_transparent_dispatch(
     ::typeof(distance),
@@ -274,9 +267,6 @@ function decorator_transparent_dispatch(
     args...,
 )
     return Val(:intransparent)
-end
-function decorator_transparent_dispatch(::typeof(exp), ::AbstractEmbeddedManifold, args...)
-    return Val(:parent)
 end
 function decorator_transparent_dispatch(
     ::typeof(exp),
@@ -346,13 +336,6 @@ function decorator_transparent_dispatch(
 end
 function decorator_transparent_dispatch(
     ::typeof(inverse_retract),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(inverse_retract),
     ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
     args...,
 ) where {𝔽}
@@ -379,10 +362,6 @@ function decorator_transparent_dispatch(
 ) where {𝔽}
     return Val(:transparent)
 end
-
-function decorator_transparent_dispatch(::typeof(log), ::AbstractEmbeddedManifold, args...)
-    return Val(:parent)
-end
 function decorator_transparent_dispatch(
     ::typeof(log),
     ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
@@ -402,13 +381,6 @@ function decorator_transparent_dispatch(
 end
 function decorator_transparent_dispatch(
     ::typeof(mid_point),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(mid_point),
     ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
     args...,
 ) where {𝔽}
@@ -427,9 +399,6 @@ function decorator_transparent_dispatch(
     args...,
 ) where {𝔽}
     return Val(:transparent)
-end
-function decorator_transparent_dispatch(::typeof(norm), ::AbstractEmbeddedManifold, args...)
-    return Val(:parent)
 end
 function decorator_transparent_dispatch(
     ::typeof(norm),
@@ -478,13 +447,6 @@ function decorator_transparent_dispatch(::typeof(project), ::EmbeddedManifold, a
 end
 function decorator_transparent_dispatch(
     ::typeof(retract),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(retract),
     ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
     args...,
 ) where {𝔽}
@@ -513,13 +475,6 @@ function decorator_transparent_dispatch(
 end
 function decorator_transparent_dispatch(
     ::typeof(vector_transport_along),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_along),
     ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
     args...,
 ) where {𝔽}
@@ -541,13 +496,6 @@ function decorator_transparent_dispatch(
 end
 function decorator_transparent_dispatch(
     ::typeof(vector_transport_direction),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_direction),
     ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
     args...,
 ) where {𝔽}
@@ -566,13 +514,6 @@ function decorator_transparent_dispatch(
     args...,
 ) where {𝔽}
     return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_to),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
 end
 function decorator_transparent_dispatch(
     ::typeof(vector_transport_to),

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -259,6 +259,9 @@ for f in [
     mid_point!,
     project,
     retract!,
+    vector_transport_along,
+    vector_transport_direction,
+    vector_transport_to,
 ]
     eval(
         quote
@@ -286,7 +289,7 @@ for f in [inverse_retract!, retract!]
         end,
     )
 end
-for f in [norm]
+for f in [norm, inner]
     eval(
         quote
             function decorator_transparent_dispatch(

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -232,7 +232,8 @@ default_embedding_dispatch(::AbstractEmbeddedManifold) = Val(false)
 
 #
 # Abstract intransparent – i.e. new implementations necessary
-for f in [check_point,check_vector, embed!, exp!, inner, log!, manifold_dimension, project!]
+for f in
+    [check_point, check_vector, embed!, exp!, inner, log!, manifold_dimension, project!]
     eval(
         quote
             function decorator_transparent_dispatch(
@@ -242,12 +243,23 @@ for f in [check_point,check_vector, embed!, exp!, inner, log!, manifold_dimensio
             )
                 return Val(:intransparent)
             end
-        end
+        end,
     )
 end
 #
 # Abstract parent – i.e. pass to embedding
-for f in [embed, get_basis, get_coordinates, get_coordinates!, get_vector, get_vector!, inverse_retract!, mid_point!, project, retract!, vector_transport_along!, vector_transport_direction!, vector_transport_to!]
+for f in [
+    embed,
+    get_basis,
+    get_coordinates,
+    get_coordinates!,
+    get_vector,
+    get_vector!,
+    inverse_retract!,
+    mid_point!,
+    project,
+    retract!,
+]
     eval(
         quote
             function decorator_transparent_dispatch(
@@ -257,7 +269,7 @@ for f in [embed, get_basis, get_coordinates, get_coordinates!, get_vector, get_v
             )
                 return Val(:parent)
             end
-        end
+        end,
     )
 end
 # Abstract generic isometric
@@ -271,7 +283,7 @@ for f in [inverse_retract!, retract!]
             ) where {𝔽}
                 return Val(:parent)
             end
-        end
+        end,
     )
 end
 for f in [norm]
@@ -284,12 +296,30 @@ for f in [norm]
             ) where {𝔽}
                 return Val(:transparent)
             end
-        end
+        end,
     )
 end
 #
 # Transparent Isometric Embedding – additionally transparent
-for f in [distance, exp, exp!, inner, inverse_retract, inverse_retract!, log, log!, mid_point, mid_point!, project!, project, retract, retract!, vector_transport_along, vector_transport_along!, vector_transport_direction, vector_transport_direction!, vector_transport_to, vector_transport_to!]
+for f in [
+    distance,
+    exp,
+    exp!,
+    inner,
+    inverse_retract,
+    inverse_retract!,
+    log,
+    log!,
+    mid_point,
+    mid_point!,
+    project!,
+    project,
+    retract,
+    retract!,
+    vector_transport_along,
+    vector_transport_direction,
+    vector_transport_to,
+]
     eval(
         quote
             function decorator_transparent_dispatch(
@@ -299,7 +329,7 @@ for f in [distance, exp, exp!, inner, inverse_retract, inverse_retract!, log, lo
             ) where {𝔽}
                 return Val(:transparent)
             end
-        end
+        end,
     )
 end
 #
@@ -314,7 +344,7 @@ for f in [embed, project]
             )
                 return Val(:intransparent)
             end
-        end
+        end,
     )
 end
 
@@ -344,9 +374,9 @@ for f in [vector_transport_along!, vector_transport_direction!, vector_transport
             ) where {𝔽,T}
                 return Val(:transparent)
             end
-        end
+        end,
     )
-    for m in [PoleLadderTransport,SchildsLadderTransport, ScaledVectorTransport]
+    for m in [PoleLadderTransport, SchildsLadderTransport, ScaledVectorTransport]
         eval(
             quote
                 function decorator_transparent_dispatch(
@@ -356,8 +386,8 @@ for f in [vector_transport_along!, vector_transport_direction!, vector_transport
                     p,
                     X,
                     q,
-                    ::$m
-                    ) where {𝔽,E}
+                    ::$m,
+                ) where {𝔽,E}
                     return Val(:parent)
                 end
                 function decorator_transparent_dispatch(
@@ -367,11 +397,11 @@ for f in [vector_transport_along!, vector_transport_direction!, vector_transport
                     p,
                     X,
                     q,
-                    ::$m
+                    ::$m,
                 ) where {𝔽}
                     return Val(:parent)
                 end
-            end
+            end,
         )
     end
 end

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -230,339 +230,148 @@ By default this is set to `Val(false)`.
 """
 default_embedding_dispatch(::AbstractEmbeddedManifold) = Val(false)
 
-function decorator_transparent_dispatch(
-    ::typeof(check_point),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:intransparent)
+#
+# Abstract intransparent – i.e. new implementations necessary
+for f in [check_point,check_vector, embed!, exp!, inner, log!, manifold_dimension, project!]
+    eval(
+        quote
+            function decorator_transparent_dispatch(
+                ::typeof($f),
+                ::AbstractEmbeddedManifold,
+                args...,
+            )
+                return Val(:intransparent)
+            end
+        end
+    )
 end
-function decorator_transparent_dispatch(
-    ::typeof(check_vector),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:intransparent)
+#
+# Abstract parent – i.e. pass to embedding
+for f in [embed, get_basis, get_coordinates, get_coordinates!, get_vector, get_vector!, inverse_retract!, mid_point!, project, retract!, vector_transport_along!, vector_transport_direction!, vector_transport_to!]
+    eval(
+        quote
+            function decorator_transparent_dispatch(
+                ::typeof($f),
+                ::AbstractEmbeddedManifold,
+                args...,
+            )
+                return Val(:parent)
+            end
+        end
+    )
 end
-function decorator_transparent_dispatch(
-    ::typeof(distance),
-    ::AbstractEmbeddedManifold{𝔽,TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
+# Abstract generic isometric
+for f in [inverse_retract!, retract!]
+    eval(
+        quote
+            function decorator_transparent_dispatch(
+                ::typeof($f),
+                ::AbstractEmbeddedManifold{𝔽,<:AbstractIsometricEmbeddingType},
+                args...,
+            ) where {𝔽}
+                return Val(:parent)
+            end
+        end
+    )
 end
-function decorator_transparent_dispatch(
-    ::typeof(embed),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
+for f in [norm]
+    eval(
+        quote
+            function decorator_transparent_dispatch(
+                ::typeof($f),
+                ::AbstractEmbeddedManifold{𝔽,<:AbstractIsometricEmbeddingType},
+                args...,
+            ) where {𝔽}
+                return Val(:transparent)
+            end
+        end
+    )
 end
-function decorator_transparent_dispatch(::typeof(embed), ::EmbeddedManifold, args...)
-    return Val(:intransparent)
+#
+# Transparent Isometric Embedding – additionally transparent
+for f in [distance, exp, exp!, inner, inverse_retract, inverse_retract!, log, log!, mid_point, mid_point!, project!, project, retract, retract!, vector_transport_along, vector_transport_along!, vector_transport_direction, vector_transport_direction!, vector_transport_to, vector_transport_to!]
+    eval(
+        quote
+            function decorator_transparent_dispatch(
+                ::typeof($f),
+                ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
+                args...,
+            ) where {𝔽}
+                return Val(:transparent)
+            end
+        end
+    )
 end
-function decorator_transparent_dispatch(
-    ::typeof(embed!),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:intransparent)
+#
+# For explicit EmbeddingManifolds the following have to be reimplemented (:intransparent)
+for f in [embed, project]
+    eval(
+        quote
+            function decorator_transparent_dispatch(
+                ::typeof($f),
+                ::EmbeddedManifold,
+                args...,
+            )
+                return Val(:intransparent)
+            end
+        end
+    )
 end
-function decorator_transparent_dispatch(
-    ::typeof(exp),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(::typeof(exp!), ::AbstractEmbeddedManifold, args...)
-    return Val(:intransparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(exp!),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(get_basis),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(get_coordinates),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(get_coordinates!),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(get_vector),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(get_vector!),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(inner),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:intransparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(inner),
-    ::AbstractEmbeddedManifold{𝔽,<:AbstractIsometricEmbeddingType},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(inverse_retract),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(inverse_retract!),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(inverse_retract!),
-    ::AbstractEmbeddedManifold{𝔽,<:AbstractIsometricEmbeddingType},
-    args...,
-) where {𝔽}
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(inverse_retract!),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(log),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(::typeof(log!), ::AbstractEmbeddedManifold, args...)
-    return Val(:intransparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(log!),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(mid_point),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(mid_point!),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(mid_point!),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(norm),
-    ::AbstractEmbeddedManifold{𝔽,<:AbstractIsometricEmbeddingType},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(manifold_dimension),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:intransparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(project!),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:intransparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(project!),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(project),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(project),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(::typeof(project), ::EmbeddedManifold, args...)
-    return Val(:intransparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(retract),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(retract!),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(retract!),
-    ::AbstractEmbeddedManifold{𝔽,<:AbstractIsometricEmbeddingType},
-    args...,
-) where {𝔽}
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(retract!),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_along),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_along!),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:intransparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_along!),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_direction),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_direction!),
-    ::AbstractEmbeddedManifold,
-    args...,
-)
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_direction!),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_to),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    args...,
-) where {𝔽}
-    return Val(:transparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_to!),
-    ::AbstractEmbeddedManifold{𝔽,<:E},
-    Y,
-    p,
-    X,
-    q,
-    ::T,
-) where {𝔽,T,E}
-    return Val(:intransparent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_to!),
-    ::AbstractEmbeddedManifold{𝔽,<:E},
-    Y,
-    p,
-    X,
-    q,
-    ::Union{PoleLadderTransport,SchildsLadderTransport},
-) where {𝔽,E}
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_to!),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    Y,
-    p,
-    X,
-    q,
-    ::Union{PoleLadderTransport,SchildsLadderTransport},
-) where {𝔽}
-    return Val(:parent)
-end
-function decorator_transparent_dispatch(
-    ::typeof(vector_transport_to!),
-    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
-    Y,
-    p,
-    X,
-    q,
-    ::T,
-) where {𝔽,T}
-    return Val(:transparent)
+
+# unified vector transports for the three already implemented cases.
+for f in [vector_transport_along!, vector_transport_direction!, vector_transport_to!]
+    eval(
+        quote
+            function decorator_transparent_dispatch(
+                ::typeof($f),
+                ::AbstractEmbeddedManifold{𝔽,<:E},
+                Y,
+                p,
+                X,
+                q,
+                ::T,
+            ) where {𝔽,T,E}
+                return Val(:intransparent)
+            end
+            function decorator_transparent_dispatch(
+                ::typeof($f),
+                ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
+                Y,
+                p,
+                X,
+                q,
+                ::T,
+            ) where {𝔽,T}
+                return Val(:transparent)
+            end
+        end
+    )
+    for m in [PoleLadderTransport,SchildsLadderTransport, ScaledVectorTransport]
+        eval(
+            quote
+                function decorator_transparent_dispatch(
+                    ::typeof($f),
+                    ::AbstractEmbeddedManifold{𝔽,<:E},
+                    Y,
+                    p,
+                    X,
+                    q,
+                    ::$m
+                    ) where {𝔽,E}
+                    return Val(:parent)
+                end
+                function decorator_transparent_dispatch(
+                    ::typeof($f),
+                    ::AbstractEmbeddedManifold{𝔽,<:TransparentIsometricEmbedding},
+                    Y,
+                    p,
+                    X,
+                    q,
+                    ::$m
+                ) where {𝔽}
+                    return Val(:parent)
+                end
+            end
+        )
+    end
 end

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -550,6 +550,8 @@ export AbstractPowerManifold, PowerManifold
 export AbstractPowerRepresentation,
     NestedPowerRepresentation, NestedReplacingPowerRepresentation
 
+export AbstractDecoratorType, DefaultDecoratorType
+
 export OutOfInjectivityRadiusError
 
 export AbstractRetractionMethod,

--- a/src/ValidationManifold.jl
+++ b/src/ValidationManifold.jl
@@ -9,7 +9,8 @@ encapsulated/stripped automatically when needed.
 This manifold is a decorator for a manifold, i.e. it decorates a [`AbstractManifold`](@ref) `M`
 with types points, vectors, and covectors.
 """
-struct ValidationManifold{𝔽,M<:AbstractManifold{𝔽}} <: AbstractDecoratorManifold{𝔽}
+struct ValidationManifold{𝔽,M<:AbstractManifold{𝔽}} <:
+       AbstractDecoratorManifold{𝔽,DefaultDecoratorType}
     manifold::M
 end
 

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -340,7 +340,7 @@ function combine_allocation_promotion_functions(::typeof(identity), ::typeof(com
 end
 
 @doc raw"""
-    dual_basis(M::AbstractManifold, p, B::AbstractBasis) 
+    dual_basis(M::AbstractManifold, p, B::AbstractBasis)
 
 Get the dual basis to `B`, a basis of a vector space at point `p` from manifold `M`.
 
@@ -533,13 +533,6 @@ for BT in [DISAMBIGUATION_BASIS_TYPES..., DISAMBIGUATION_COTANGENT_BASIS_TYPES..
         end,
     )
 end
-function decorator_transparent_dispatch(
-    ::typeof(get_coordinates!),
-    ::AbstractManifold,
-    args...,
-)
-    return Val(:transparent)
-end
 
 function get_coordinates!(M::AbstractManifold, Y, p, X, B::VeeOrthogonalBasis)
     return get_coordinates!(M, Y, p, X, DefaultOrthogonalBasis(number_system(B)))
@@ -631,9 +624,6 @@ for BT in [DISAMBIGUATION_BASIS_TYPES..., DISAMBIGUATION_COTANGENT_BASIS_TYPES..
             )
         end,
     )
-end
-function decorator_transparent_dispatch(::typeof(get_vector!), ::AbstractManifold, args...)
-    return Val(:transparent)
 end
 
 _get_vector_cache_broadcast(::Any) = Val(true)

--- a/test/decorator_manifold.jl
+++ b/test/decorator_manifold.jl
@@ -7,11 +7,12 @@ using ManifoldsBase:
     is_decorator_transparent
 import ManifoldsBase: decorator_transparent_dispatch
 
-struct TestDecorator{M<:AbstractManifold{ℝ}} <: AbstractDecoratorManifold{ℝ,DefaultDecoratorType}
+struct TestDecorator{M<:AbstractManifold{ℝ}} <:
+       AbstractDecoratorManifold{ℝ,DefaultDecoratorType}
     manifold::M
 end
 
-abstract type AbstractTestDecorator <: AbstractDecoratorManifold{ℝ, DefaultDecoratorType} end
+abstract type AbstractTestDecorator <: AbstractDecoratorManifold{ℝ,DefaultDecoratorType} end
 
 struct TestDecorator2{M<:AbstractManifold{ℝ}} <: AbstractTestDecorator
     manifold::M
@@ -21,13 +22,14 @@ struct TestDecorator3{M<:AbstractManifold{ℝ}} <: AbstractTestDecorator
     manifold::M
 end
 
-abstract type AbstractParentDecorator <: AbstractDecoratorManifold{ℝ, DefaultDecoratorType} end
+abstract type AbstractParentDecorator <: AbstractDecoratorManifold{ℝ,DefaultDecoratorType} end
 
 struct ChildDecorator{M<:AbstractManifold{ℝ}} <: AbstractParentDecorator
     manifold::M
 end
 
-struct DefaultDecorator{M<:AbstractManifold{ℝ}} <: AbstractDecoratorManifold{ℝ, DefaultDecoratorType}
+struct DefaultDecorator{M<:AbstractManifold{ℝ}} <:
+       AbstractDecoratorManifold{ℝ,DefaultDecoratorType}
     manifold::M
 end
 ManifoldsBase.default_decorator_dispatch(::DefaultDecorator) = Val(true)

--- a/test/decorator_manifold.jl
+++ b/test/decorator_manifold.jl
@@ -7,11 +7,11 @@ using ManifoldsBase:
     is_decorator_transparent
 import ManifoldsBase: decorator_transparent_dispatch
 
-struct TestDecorator{M<:AbstractManifold{ℝ}} <: AbstractDecoratorManifold{ℝ}
+struct TestDecorator{M<:AbstractManifold{ℝ}} <: AbstractDecoratorManifold{ℝ,DefaultDecoratorType}
     manifold::M
 end
 
-abstract type AbstractTestDecorator <: AbstractDecoratorManifold{ℝ} end
+abstract type AbstractTestDecorator <: AbstractDecoratorManifold{ℝ, DefaultDecoratorType} end
 
 struct TestDecorator2{M<:AbstractManifold{ℝ}} <: AbstractTestDecorator
     manifold::M
@@ -21,13 +21,13 @@ struct TestDecorator3{M<:AbstractManifold{ℝ}} <: AbstractTestDecorator
     manifold::M
 end
 
-abstract type AbstractParentDecorator <: AbstractDecoratorManifold{ℝ} end
+abstract type AbstractParentDecorator <: AbstractDecoratorManifold{ℝ, DefaultDecoratorType} end
 
 struct ChildDecorator{M<:AbstractManifold{ℝ}} <: AbstractParentDecorator
     manifold::M
 end
 
-struct DefaultDecorator{M<:AbstractManifold{ℝ}} <: AbstractDecoratorManifold{ℝ}
+struct DefaultDecorator{M<:AbstractManifold{ℝ}} <: AbstractDecoratorManifold{ℝ, DefaultDecoratorType}
     manifold::M
 end
 ManifoldsBase.default_decorator_dispatch(::DefaultDecorator) = Val(true)

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -276,7 +276,7 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
                   Val(:intransparent)
         end
         @test ManifoldsBase.decorator_transparent_dispatch(vector_transport_along!, AM) ===
-              Val(:intransparent)
+              Val(:transparent)
         @test ManifoldsBase.decorator_transparent_dispatch(
             vector_transport_to!,
             AM,
@@ -289,7 +289,7 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         @test ManifoldsBase.decorator_transparent_dispatch(
             vector_transport_direction!,
             AM,
-        ) === Val(:parent)
+        ) === Val(:transparent)
 
         for f in [inner, norm]
             @test ManifoldsBase.decorator_transparent_dispatch(f, IM) === Val(:transparent)

--- a/test/power.jl
+++ b/test/power.jl
@@ -5,7 +5,7 @@ using StaticArrays
 
 struct DummyPowerRepresentation <: AbstractPowerRepresentation end
 struct DummyDecorator{TM<:AbstractManifold{ManifoldsBase.ℝ}} <:
-       AbstractDecoratorManifold{ManifoldsBase.ℝ, DefaultDecoratorType}
+       AbstractDecoratorManifold{ManifoldsBase.ℝ,DefaultDecoratorType}
     manifold::TM
 end
 

--- a/test/power.jl
+++ b/test/power.jl
@@ -5,7 +5,7 @@ using StaticArrays
 
 struct DummyPowerRepresentation <: AbstractPowerRepresentation end
 struct DummyDecorator{TM<:AbstractManifold{ManifoldsBase.ℝ}} <:
-       AbstractDecoratorManifold{ManifoldsBase.ℝ}
+       AbstractDecoratorManifold{ManifoldsBase.ℝ, DefaultDecoratorType}
     manifold::TM
 end
 


### PR DESCRIPTION
This PR is WIP to introduce a nicer (shorter) way of introducing decorators.
The `AbstractDecoratorType` is a supertype of the embedding type we already have, on the abstract level of the decorator manifold and is meant to work similarly.

This should currently already work, is backward compatible for everything “below” the AbstractDecoratorManifold, while this type itself got a second parameter (so in general that should also still work, I hope).

For example the new `DefaultMetricDecorator` can be used for completely new features, i.e. when a decorator introduces functions but does not affect old ones. 

* [x] introduce the new type and clean up the two existing decorators to have less dispatch rules defined.
* [x] check for easy entrance types to also provide, i.e. something like `DefaultMetricDecorator` which acts transparent unless the metric is involved, and ideas like that.
* [x] update documentation
* [x] if we have a good idea how to restyle the decorator approach, i.e. internal optimization, that would also be good