### PR TITLE
Fixes two transparencies 

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.12.0"
+version = "0.12.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -261,6 +261,7 @@ for f in [
     retract!,
     vector_transport_along,
     vector_transport_direction,
+    vector_transport_direction!,
     vector_transport_to,
 ]
     eval(
@@ -321,6 +322,7 @@ for f in [
     retract!,
     vector_transport_along,
     vector_transport_direction,
+    vector_transport_direction!,
     vector_transport_to,
 ]
     eval(
@@ -351,7 +353,8 @@ for f in [embed, project]
     )
 end
 
-# unified vector transports for the three already implemented cases.
+# unified vector transports for the three already implemented cases,
+# where _direction! still has its nice fallback
 for f in [vector_transport_along!, vector_transport_direction!, vector_transport_to!]
     eval(
         quote

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -355,7 +355,7 @@ end
 
 # unified vector transports for the three already implemented cases,
 # where _direction! still has its nice fallback
-for f in [vector_transport_along!, vector_transport_direction!, vector_transport_to!]
+for f in [vector_transport_along!, vector_transport_to!]
     eval(
         quote
             function decorator_transparent_dispatch(

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -289,7 +289,7 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         @test ManifoldsBase.decorator_transparent_dispatch(
             vector_transport_direction!,
             AM,
-        ) === Val(:transparent)
+        ) === Val(:parent)
 
         for f in [inner, norm]
             @test ManifoldsBase.decorator_transparent_dispatch(f, IM) === Val(:transparent)


### PR DESCRIPTION
Introduce two fixes for vector_transport_direction! that were missed when transcribing.