### PR TITLE
Fix and stabilise gram_schmidt.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.12.4"
+version = "0.12.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -707,6 +707,24 @@ When a set of vectors is orthonormalized a set of vectors is returned.
 When an [`AbstractBasis`](@ref) is orthonormalized, a [`CachedBasis`](@ref) is returned.
 """
 function gram_schmidt(
+    M::AbstractManifold{𝔽},
+    p,
+    B::AbstractBasis{𝔽};
+    warn_linearly_dependent = false,
+    return_incomplete_set = false,
+    kwargs...,
+) where {𝔽}
+    V = gram_schmidt(
+        M,
+        p,
+        get_vectors(M, p, B);
+        warn_linearly_dependent = warn_linearly_dependent,
+        return_incomplete_set = return_incomplete_set,
+        kwargs...,
+    )
+    return CachedBasis(GramSchmidtOrthonormalBasis(𝔽), V)
+end
+function gram_schmidt(
     M::AbstractManifold,
     p,
     V::AbstractVector;

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -744,20 +744,13 @@ function gram_schmidt(
         end
         nrmΞₙ = norm(M, p, Ξₙ)
         if nrmΞₙ == 0
-            warn_linearly_dependent && @warn "Input vector $(n) has length 0."
+            warn_linearly_dependent &&
+                @warn "Input vector $(n) lies in the span of the previous ones."
             linear_independent = false
         end
         Ξₙ ./= nrmΞₙ
-        for k in 1:length(Ξ)
-            if isapprox(abs(real(inner(M, p, Ξ[k], Ξₙ))), 1; kwargs...)
-                warn_linearly_dependent &&
-                    @warn "Input vector $(n) is not linearly independent of output basis vector $(k)."
-                linear_independent = false
-            end
-            (!linear_independent) && break
-        end
         (!linear_independent || length(Ξ) == dim) && break
-        linear_independent && push!(Ξ, Ξₙ)
+        push!(Ξ, Ξₙ)
     end
     if return_incomplete_set || length(Ξ) == dim
         return Ξ

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -756,7 +756,7 @@ function gram_schmidt(
             end
             (!linear_independent) && break
         end
-        (!linear_independent || length(Ξ) == dim) && break
+        (!linear_independent || length(Ξ) == dim) && break
         linear_independent && push!(Ξ, Ξₙ)
     end
     if return_incomplete_set || length(Ξ) == dim

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -724,7 +724,7 @@ function gram_schmidt(
     M::AbstractManifold,
     p,
     V::AbstractVector;
-    atol = 5 * 1e-16,
+    atol = eps(number_eltype(first(V))),
     warn_linearly_dependent = false,
     return_incomplete_set = false,
     skip_linearly_dependent = false,

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -687,7 +687,7 @@ The method always returns a basis, i.e. linearly dependent vectors are removed.
 
 * `warn_linearly_dependent` (`false`) – warn if the basis vectors are not linearly
   independent
-* `skip_linearly_dependent` (`false`) – whether to just skip (`true`) linear a vector that
+* `skip_linearly_dependent` (`false`) – whether to just skip (`true`) a vector that
   is linearly dependent to the previous ones or to stop (`false`, default) at that point
 * `return_incomplete_set` (`false`) – throw an error if the resulting set of vectors is not
   a basis but contains less vectors

--- a/test/bases.jl
+++ b/test/bases.jl
@@ -64,10 +64,20 @@ ManifoldsBase.manifold_dimension(::ProjectionTestManifold) = 100
         0.0 sqrt(2)/2 0.0
     ]
 
-    for pb in (ProjectedOrthonormalBasis(:svd), ProjectedOrthonormalBasis(:gram_schmidt))
-        pb = get_basis(M, x, pb)
+    for pB in (ProjectedOrthonormalBasis(:svd), ProjectedOrthonormalBasis(:gram_schmidt))
+        if pB isa ProjectedOrthonormalBasis{:gram_schmidt,ℝ}
+            pb = get_basis(
+                M,
+                x,
+                pB;
+                warn_linearly_dependent = true,
+                skip_linearly_dependent = true,
+            ) # skip V4, wich is -V1 after proj.
+            @test_throws ErrorException get_basis(M, x, pB) # error
+        else
+            pb = get_basis(M, x, pB) # skips V4 automatically
+        end
         @test number_system(pb) == ℝ
-        @test get_basis(M, x, pb) == pb
         N = manifold_dimension(M)
         @test isa(pb, CachedBasis)
         @test CachedBasis(pb) === pb
@@ -103,9 +113,9 @@ ManifoldsBase.manifold_dimension(::ProjectionTestManifold) = 100
             p,
             bt;
             return_incomplete_set = true,
-            warn_linearly_dependent = true,
+            skip_linearly_dependent = true, #skips 3 and 5
         )
-        @test length(get_vectors(tm, p, b)) == 4
+        @test length(get_vectors(tm, p, b)) == 3
     end
 end
 

--- a/test/bases.jl
+++ b/test/bases.jl
@@ -76,7 +76,6 @@ ManifoldsBase.manifold_dimension(::ProjectionTestManifold) = 100
         for i in 1:N
             @test norm(M, x, get_vectors(M, x, pb)[i]) ≈ 1
             for j in (i + 1):N
-            println(i," -- ",j)
                 @test inner(M, x, get_vectors(M, x, pb)[i], get_vectors(M, x, pb)[j]) ≈ 0 atol =
                     1e-15
             end

--- a/test/bases.jl
+++ b/test/bases.jl
@@ -116,6 +116,13 @@ ManifoldsBase.manifold_dimension(::ProjectionTestManifold) = 100
             skip_linearly_dependent = true, #skips 3 and 5
         )
         @test length(get_vectors(tm, p, b)) == 3
+        @test_throws ErrorException ManifoldsBase.gram_schmidt(M, p, [V[1]])
+        @test_throws ErrorException ManifoldsBase.gram_schmidt(
+            M,
+            p,
+            [V[1], V[1], V[1]];
+            skip_linearly_dependent = true,
+        )
     end
 end
 

--- a/test/bases.jl
+++ b/test/bases.jl
@@ -76,13 +76,10 @@ ManifoldsBase.manifold_dimension(::ProjectionTestManifold) = 100
         for i in 1:N
             @test norm(M, x, get_vectors(M, x, pb)[i]) ≈ 1
             for j in (i + 1):N
+            println(i," -- ",j)
                 @test inner(M, x, get_vectors(M, x, pb)[i], get_vectors(M, x, pb)[j]) ≈ 0 atol =
                     1e-15
             end
-        end
-        # check projection idempotency
-        for i in 1:N
-            @test project(M, x, get_vectors(M, x, pb)[i]) ≈ get_vectors(M, x, pb)[i]
         end
     end
     aonb = get_basis(M, x, DefaultOrthonormalBasis())
@@ -109,7 +106,7 @@ ManifoldsBase.manifold_dimension(::ProjectionTestManifold) = 100
             return_incomplete_set = true,
             warn_linearly_dependent = true,
         )
-        @test length(get_vectors(tm, p, b)) == 3
+        @test length(get_vectors(tm, p, b)) == 4
     end
 end
 


### PR DESCRIPTION
Yesterday I ran into a bug with a student, where entering with an ONB into Gram Schmidt we did not get a full basis back (either an error or a incomplete set).
The problem was, that the old variant was too unstable. The new one checks, whether the obtained vector is linear dependent with any of the previous ones.
I also added that the input (V) is no longer modified, since `gram_schmidt` is without a dash. However - now one of the tests fails where the comment says it checks that projection is idempotent and I do not understand why that test should test that.