### PR TITLE
Make copy and copyto! transparent.

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.12.3"
+version = "0.12.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/DecoratorManifold.jl
+++ b/src/DecoratorManifold.jl
@@ -780,6 +780,8 @@ Base.@propagate_inbounds function Base.getindex(
 end
 
 DEFAULT_PARENT_FUNCTIONS = [
+    copy,
+    copyto!,
     distance,
     exp,
     inner,

--- a/src/DecoratorManifold.jl
+++ b/src/DecoratorManifold.jl
@@ -530,7 +530,9 @@ Return the manifold decorated by the decorator `M`. Defaults to `M.manifold`.
 decorated_manifold(M::AbstractManifold) = M.manifold
 
 @decorator_transparent_signature copyto!(M::AbstractDecoratorManifold, q, p)
+@decorator_transparent_signature copyto!(M::AbstractDecoratorManifold, Y, p, X)
 @decorator_transparent_signature copy(M::AbstractDecoratorManifold, p)
+@decorator_transparent_signature copy(M::AbstractDecoratorManifold, p, X)
 
 @decorator_transparent_signature distance(M::AbstractDecoratorManifold, p, q)
 

--- a/src/DecoratorManifold.jl
+++ b/src/DecoratorManifold.jl
@@ -780,8 +780,6 @@ Base.@propagate_inbounds function Base.getindex(
 end
 
 DEFAULT_PARENT_FUNCTIONS = [
-    copy,
-    copyto!,
     distance,
     exp,
     inner,

--- a/src/DecoratorManifold.jl
+++ b/src/DecoratorManifold.jl
@@ -529,6 +529,9 @@ Return the manifold decorated by the decorator `M`. Defaults to `M.manifold`.
 """
 decorated_manifold(M::AbstractManifold) = M.manifold
 
+@decorator_transparent_signature copyto!(M::AbstractDecoratorManifold, q, p)
+@decorator_transparent_signature copy(M::AbstractDecoratorManifold, p)
+
 @decorator_transparent_signature distance(M::AbstractDecoratorManifold, p, q)
 
 @decorator_transparent_signature embed(M::AbstractDecoratorManifold, p, X)

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -249,6 +249,8 @@ end
 #
 # Abstract parent – i.e. pass to embedding
 for f in [
+    copy,
+    copyto!,
     embed,
     get_basis,
     get_coordinates,


### PR DESCRIPTION
This is just a small PR (to see code coverage) – I am introducing copy and copyto! to be transparent functions by default.