### PR TITLE
Faster `allocate_result_type`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.12.5"
+version = "0.12.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -83,7 +83,8 @@ Return type of element of the array that will represent the result of function `
 [`AbstractManifold`](@ref) `M` on given arguments `args` (passed as a tuple).
 """
 function allocate_result_type(::AbstractManifold, f, args::NTuple{N,Any}) where {N}
-    return typeof(mapreduce(eti -> one(number_eltype(eti)), +, args))
+    @inline eti_to_one(eti) = one(number_eltype(eti))
+    return typeof(mapreduce(eti_to_one, +, args))
 end
 
 """


### PR DESCRIPTION
Makes Julia more eager to inline what should be inlined. Solves one part of https://github.com/JuliaManifolds/Manifolds.jl/issues/412 .