### PR TITLE
Introduce defaults for atol and rtol for is_point and is_vector

### DIFF
--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -417,8 +417,8 @@ function is_point(
     M::AbstractManifold,
     p,
     throw_error = false;
-    atol::Real = 0,
-    rtol = atol > 0 ? 0 : sqrt(eps(number_eltype(p))),
+    atol::Real = zero(number_eltype(p)),
+    rtol = atol > zero(float(number_eltype(p))) ? zero(float(number_eltype(p))) : sqrt(eps(float(number_eltype(p)))),
     kwargs...,
 )
     mpe = check_point(M, p; atol = atol, rtol = rtol, kwargs...)
@@ -446,8 +446,8 @@ function is_vector(
     X,
     throw_error = false;
     check_base_point = true,
-    atol = 0.0,
-    rtol = atol > 0 ? 0 : sqrt(eps(number_eltype(X))),
+    atol = zero(number_eltype(X)),
+    rtol = atol > zero(float(number_eltype(X))) ? zero(float(number_eltype(X))) : sqrt(eps(float(number_eltype(X)))),
     kwargs...,
 )
     if check_base_point

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -413,8 +413,15 @@ is `true`, the function either returns `true` or throws an error. By default the
 calls [`check_point(M, p; kwargs...)`](@ref) and checks whether the returned value
 is `nothing` or an error.
 """
-function is_point(M::AbstractManifold, p, throw_error = false; kwargs...)
-    mpe = check_point(M, p; kwargs...)
+function is_point(
+    M::AbstractManifold,
+    p,
+    throw_error = false;
+    atol::Real = 0,
+    rtol = atol > 0 ? 0 : sqrt(eps(number_eltype(p))),
+    kwargs...,
+)
+    mpe = check_point(M, p; atol = atol, rtol = rtol, kwargs...)
     mpe === nothing && return true
     return throw_error ? throw(mpe) : false
 end
@@ -439,10 +446,12 @@ function is_vector(
     X,
     throw_error = false;
     check_base_point = true,
+    atol = 0.0,
+    rtol = atol > 0 ? 0 : sqrt(eps(number_eltype(X))),
     kwargs...,
 )
     if check_base_point
-        mpe = check_point(M, p; kwargs...)
+        mpe = check_point(M, p; atol = atol, rtol = rtol, kwargs...)
         if mpe !== nothing
             if throw_error
                 throw(mpe)
@@ -451,7 +460,7 @@ function is_vector(
             end
         end
     end
-    mtve = check_vector(M, p, X; kwargs...)
+    mtve = check_vector(M, p, X; atol = atol, rtol = rtol, kwargs...)
     mtve === nothing && return true
     return throw_error ? throw(mtve) : false
 end

--- a/test/domain_errors.jl
+++ b/test/domain_errors.jl
@@ -3,13 +3,13 @@ using Test
 
 struct ErrorTestManifold <: AbstractManifold{ℝ} end
 
-function ManifoldsBase.check_point(::ErrorTestManifold, x)
+function ManifoldsBase.check_point(::ErrorTestManifold, x; kwargs...)
     if any(u -> u < 0, x)
         return DomainError(x, "<0")
     end
     return nothing
 end
-function ManifoldsBase.check_vector(M::ErrorTestManifold, x, v)
+function ManifoldsBase.check_vector(M::ErrorTestManifold, x, v; kwargs...)
     mpe = check_point(M, x)
     mpe === nothing || return mpe
     if any(u -> u < 0, v)
@@ -22,13 +22,13 @@ end
     M = ErrorTestManifold()
     @test isa(check_point(M, [-1, 1]), DomainError)
     @test check_point(M, [1, 1]) === nothing
-    @test !is_point(M, [-1, 1])
-    @test is_point(M, [1, 1])
-    @test_throws DomainError is_point(M, [-1, 1], true)
+    @test !is_point(M, [-1.0, 1.0])
+    @test is_point(M, [1.0, 1.0])
+    @test_throws DomainError is_point(M, [-1.0, 1.0], true)
 
     @test isa(check_vector(M, [1, 1], [-1, 1]), DomainError)
     @test check_vector(M, [1, 1], [1, 1]) === nothing
-    @test !is_vector(M, [1, 1], [-1, 1])
-    @test is_vector(M, [1, 1], [1, 1])
-    @test_throws DomainError is_vector(M, [1, 1], [-1, 1], true)
+    @test !is_vector(M, [1.0, 1.0], [-1.0, 1.0])
+    @test is_vector(M, [1.0, 1.0], [1.0, 1.0])
+    @test_throws DomainError is_vector(M, [1.0, 1.0], [-1.0, 1.0], true)
 end

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -114,12 +114,12 @@ struct NotImplementedEmbeddedManifold3 <: AbstractEmbeddedManifold{ℝ,DefaultEm
         @test ManifoldsBase.default_embedding_dispatch(M) === Val(false)
         @test get_embedding(M) == ManifoldsBase.DefaultManifold(1, 3)
         # Check fallbacks to check embed->check_manifoldpoint Defaults
-        @test_throws DomainError is_point(M, [1, 0, 0], true)
-        @test_throws DomainError is_point(M, [1 0], true)
-        @test is_point(M, [1 0 0], true)
-        @test_throws DomainError is_vector(M, [1 0 0], [1], true)
-        @test_throws DomainError is_vector(M, [1 0 0], [0 0 0 0], true)
-        @test is_vector(M, [1 0 0], [1 0 1], true)
+        @test_throws DomainError is_point(M, [1.0, 0.0, 0.0], true)
+        @test_throws DomainError is_point(M, [1.0 0.0], true)
+        @test is_point(M, [1.0 0.0 0.0], true)
+        @test_throws DomainError is_vector(M, [1.0 0.0 0.0], [1.0], true)
+        @test_throws DomainError is_vector(M, [1.0 0.0 0.0], [0.0 0.0 0.0 0.0], true)
+        @test is_vector(M, [1.0 0.0 0.0], [1.0 0.0 1.0], true)
         p = [1.0 1.0 0.0]
         q = [1.0 0.0 0.0]
         X = q - p

--- a/test/empty_manifold.jl
+++ b/test/empty_manifold.jl
@@ -138,12 +138,12 @@ struct NotImplementedInverseRetraction <: AbstractInverseRetractionMethod end
 
     @test check_point(M, [0]) === nothing
     @test check_point(M, p) === nothing
-    @test is_point(M, [0])
+    @test is_point(M, [0.0])
     @test check_point(M, [0]) === nothing
 
     @test check_vector(M, [0], [0]) === nothing
     @test check_vector(M, p, v) === nothing
-    @test is_vector(M, [0], [0])
+    @test is_vector(M, [0.0], [0.0])
     @test check_vector(M, [0], [0]) === nothing
 
     @test_throws ErrorException hat!(M, [0], [0], [0])

--- a/test/validation_manifold.jl
+++ b/test/validation_manifold.jl
@@ -149,7 +149,8 @@ end
                 @test_throws DomainError get_coordinates(A, x, [1.0], cb)
                 @test_throws DomainError get_coordinates!(A, v, x, [0.0], cb)
                 @test_throws DomainError get_coordinates!(A, v, [1.0], [1.0, 0.0, 0.0], cb)
-                @test get_vector(A, x, [1.0, 2.0, 3.0], cb) ≈ get_vector(M, x, [1, 2, 3], cb)
+                @test get_vector(A, x, [1.0, 2.0, 3.0], cb) ≈
+                      get_vector(M, x, [1, 2, 3], cb)
                 @test get_vector!(A, v2, x, [1.0, 2.0, 3.0], cb) ≈
                       get_vector!(M, v, x, [1.0, 2.0, 3.0], cb)
                 @test get_coordinates(A, x, [1.0, 2.0, 3.0], cb) ≈

--- a/test/validation_manifold.jl
+++ b/test/validation_manifold.jl
@@ -144,18 +144,18 @@ end
                 v2 = similar(x)
                 @test_throws ErrorException get_vector(A, x, [1.0], cb)
                 @test_throws DomainError get_vector(A, [1.0], [1.0, 0.0, 0.0], cb)
-                @test_throws ErrorException get_vector!(A, v, x, [], cb)
+                @test_throws ErrorException get_vector!(A, v, x, [0.0], cb)
                 @test_throws DomainError get_vector!(A, v, [1.0], [1.0, 0.0, 0.0], cb)
                 @test_throws DomainError get_coordinates(A, x, [1.0], cb)
-                @test_throws DomainError get_coordinates!(A, v, x, [], cb)
+                @test_throws DomainError get_coordinates!(A, v, x, [0.0], cb)
                 @test_throws DomainError get_coordinates!(A, v, [1.0], [1.0, 0.0, 0.0], cb)
-                @test get_vector(A, x, [1, 2, 3], cb) ≈ get_vector(M, x, [1, 2, 3], cb)
-                @test get_vector!(A, v2, x, [1, 2, 3], cb) ≈
-                      get_vector!(M, v, x, [1, 2, 3], cb)
-                @test get_coordinates(A, x, [1, 2, 3], cb) ≈
-                      get_coordinates(M, x, [1, 2, 3], cb)
-                @test get_coordinates!(A, v2, x, [1, 2, 3], cb) ≈
-                      get_coordinates!(M, v, x, [1, 2, 3], cb)
+                @test get_vector(A, x, [1.0, 2.0, 3.0], cb) ≈ get_vector(M, x, [1, 2, 3], cb)
+                @test get_vector!(A, v2, x, [1.0, 2.0, 3.0], cb) ≈
+                      get_vector!(M, v, x, [1.0, 2.0, 3.0], cb)
+                @test get_coordinates(A, x, [1.0, 2.0, 3.0], cb) ≈
+                      get_coordinates(M, x, [1.0, 2.0, 3.0], cb)
+                @test get_coordinates!(A, v2, x, [1.0, 2.0, 3.0], cb) ≈
+                      get_coordinates!(M, v, x, [1.0, 2.0, 3.0], cb)
 
                 @test_throws ErrorException get_basis(A, x, CachedBasis(cb, [x]))
                 @test_throws ErrorException get_basis(A, x, CachedBasis(cb, [x, x, x]))


### PR DESCRIPTION
This PR introduces a default `atol` (=0) and rtol (`sqrt(eps)`) for the high-level functions `is_point` and `is_vector`.

The lower level `check_` functions do not have this detail, in case someone wants to be sure to not have it.
Formerly I fear this is changing a default and hence breaking change – also integer vectors do not cope well with my idea of the eps-default so if there is a better idea, feel free to mention it here.

The PR yields that
1) high-level usage is easier to use and tolerant to some extend
2) low level use can still be as exact as before. 