### PR TITLE
More strict typing of some methods

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.1"
+version = "0.13.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/point_vector_fallbacks.jl
+++ b/src/point_vector_fallbacks.jl
@@ -229,10 +229,23 @@ macro default_manifold_fallbacks(TM, TP, TV, pfield::Symbol, vfield::Symbol)
     push!(
         block.args,
         quote
-            function ManifoldsBase.retract_exp_ode(M::$TM, p::$TP, X::$TV, m, B)
+            function ManifoldsBase.retract_exp_ode(
+                M::$TM,
+                p::$TP,
+                X::$TV,
+                m::AbstractRetractionMethod,
+                B::ManifoldsBase.AbstractBasis,
+            )
                 return $TP(ManifoldsBase.retract_exp_ode(M, p.$pfield, X.$vfield, m, B))
             end
-            function ManifoldsBase.retract_exp_ode!(M::$TM, q::$TP, p::$TP, X::$TV, m, B)
+            function ManifoldsBase.retract_exp_ode!(
+                M::$TM,
+                q::$TP,
+                p::$TP,
+                X::$TV,
+                m::AbstractRetractionMethod,
+                B::ManifoldsBase.AbstractBasis,
+            )
                 ManifoldsBase.retract_exp_ode!(M, q.$pfield, p.$pfield, X.$vfield, m, B)
                 return q
             end
@@ -243,10 +256,21 @@ macro default_manifold_fallbacks(TM, TP, TV, pfield::Symbol, vfield::Symbol)
                 ManifoldsBase.retract_pade!(M, q.$pfield, p.$pfield, X.$vfield, n)
                 return q
             end
-            function ManifoldsBase.retract_embedded(M::$TM, p::$TP, X::$TV, m)
+            function ManifoldsBase.retract_embedded(
+                M::$TM,
+                p::$TP,
+                X::$TV,
+                m::AbstractRetractionMethod,
+            )
                 return $TP(ManifoldsBase.retract_embedded(M, p.$pfield, X.$vfield, m))
             end
-            function ManifoldsBase.retract_embedded!(M::$TM, q::$TP, p::$TP, X::$TV, m)
+            function ManifoldsBase.retract_embedded!(
+                M::$TM,
+                q::$TP,
+                p::$TP,
+                X::$TV,
+                m::AbstractRetractionMethod,
+            )
                 ManifoldsBase.retract_embedded!(M, q.$pfield, p.$pfield, X.$vfield, m)
                 return q
             end
@@ -268,7 +292,12 @@ macro default_manifold_fallbacks(TM, TP, TV, pfield::Symbol, vfield::Symbol)
     push!(
         block.args,
         quote
-            function ManifoldsBase.inverse_retract_embedded(M::$TM, p::$TP, q::$TP, m)
+            function ManifoldsBase.inverse_retract_embedded(
+                M::$TM,
+                p::$TP,
+                q::$TP,
+                m::AbstractInverseRetractionMethod,
+            )
                 return $TV(
                     ManifoldsBase.inverse_retract_embedded(M, p.$pfield, q.$pfield, m),
                 )
@@ -278,7 +307,7 @@ macro default_manifold_fallbacks(TM, TP, TV, pfield::Symbol, vfield::Symbol)
                 X::$TV,
                 p::$TP,
                 q::$TP,
-                m,
+                m::AbstractInverseRetractionMethod,
             )
                 ManifoldsBase.inverse_retract_embedded!(
                     M,
@@ -289,7 +318,12 @@ macro default_manifold_fallbacks(TM, TP, TV, pfield::Symbol, vfield::Symbol)
                 )
                 return X
             end
-            function ManifoldsBase.inverse_retract_nlsolve(M::$TM, p::$TP, q::$TP, m)
+            function ManifoldsBase.inverse_retract_nlsolve(
+                M::$TM,
+                p::$TP,
+                q::$TP,
+                m::NLSolveInverseRetraction,
+            )
                 return $TV(
                     ManifoldsBase.inverse_retract_nlsolve(M, p.$pfield, q.$pfield, m),
                 )
@@ -299,7 +333,7 @@ macro default_manifold_fallbacks(TM, TP, TV, pfield::Symbol, vfield::Symbol)
                 X::$TV,
                 p::$TP,
                 q::$TP,
-                m,
+                m::NLSolveInverseRetraction,
             )
                 ManifoldsBase.inverse_retract_nlsolve!(
                     M,

--- a/src/point_vector_fallbacks.jl
+++ b/src/point_vector_fallbacks.jl
@@ -183,34 +183,36 @@ macro default_manifold_fallbacks(TM, TP, TV, pfield::Symbol, vfield::Symbol)
         cm = Symbol("get_coordinates_$(f_postfix)!")
         va = Symbol("get_vector_$(f_postfix)")
         vm = Symbol("get_vector_$(f_postfix)!")
-        B_type = if f_postfix in [:default, :orthogonal, :orthonormal, :vee]
-            :AbstractNumbers
+        B_types = if f_postfix in [:default, :orthogonal, :orthonormal, :vee]
+            [:AbstractNumbers, :RealNumbers, :ComplexNumbers]
         elseif f_postfix === :cached
-            :CachedBasis
+            [:CachedBasis]
         elseif f_postfix === :diagonalizing
-            :DiagonalizingOrthonormalBasis
+            [:DiagonalizingOrthonormalBasis]
         else
-            :Any
+            [:Any]
         end
-        push!(
-            block.args,
-            quote
-                function ManifoldsBase.$ca(M::$TM, p::$TP, X::$TV, B::$B_type)
-                    return ManifoldsBase.$ca(M, p.$pfield, X.$vfield, B)
-                end
-                function ManifoldsBase.$cm(M::$TM, Y, p::$TP, X::$TV, B::$B_type)
-                    ManifoldsBase.$cm(M, Y, p.$pfield, X.$vfield, B)
-                    return Y
-                end
-                function ManifoldsBase.$va(M::$TM, p::$TP, X, B::$B_type)
-                    return $TV(ManifoldsBase.$va(M, p.$pfield, X, B))
-                end
-                function ManifoldsBase.$vm(M::$TM, Y::$TV, p::$TP, X, B::$B_type)
-                    ManifoldsBase.$vm(M, Y.$vfield, p.$pfield, X, B)
-                    return Y
-                end
-            end,
-        )
+        for B_type in B_types
+            push!(
+                block.args,
+                quote
+                    function ManifoldsBase.$ca(M::$TM, p::$TP, X::$TV, B::$B_type)
+                        return ManifoldsBase.$ca(M, p.$pfield, X.$vfield, B)
+                    end
+                    function ManifoldsBase.$cm(M::$TM, Y, p::$TP, X::$TV, B::$B_type)
+                        ManifoldsBase.$cm(M, Y, p.$pfield, X.$vfield, B)
+                        return Y
+                    end
+                    function ManifoldsBase.$va(M::$TM, p::$TP, X, B::$B_type)
+                        return $TV(ManifoldsBase.$va(M, p.$pfield, X, B))
+                    end
+                    function ManifoldsBase.$vm(M::$TM, Y::$TV, p::$TP, X, B::$B_type)
+                        ManifoldsBase.$vm(M, Y.$vfield, p.$pfield, X, B)
+                        return Y
+                    end
+                end,
+            )
+        end
     end
     # TODO  forward retraction / inverse_retraction
     for f_postfix in [:polar, :project, :qr, :softmax]

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -358,13 +358,19 @@ function _inverse_retract!(M::AbstractManifold, X, p, q, m::NLSolveInverseRetrac
     return inverse_retract_nlsolve!(M, X, p, q, m)
 end
 """
-    inverse_retract_embedded!(M::AbstractManifold, X, p, q, m)
+    inverse_retract_embedded!(M::AbstractManifold, X, p, q, m::AbstractInverseRetractionMethod)
 
 computes the mutating variant of the [`EmbeddedInverseRetraction`](@ref) using
 the [`AbstractInverseRetractionMethod`](@ref) `m` in the embedding (see [`get_embedding`](@ref))
 and projecting the result back.
 """
-function inverse_retract_embedded!(M::AbstractManifold, X, p, q, m)
+function inverse_retract_embedded!(
+    M::AbstractManifold,
+    X,
+    p,
+    q,
+    m::AbstractInverseRetractionMethod,
+)
     return project!(
         M,
         X,
@@ -425,11 +431,11 @@ inverse_retract_polar!(M::AbstractManifold, X, p, q)
 function inverse_retract_polar! end
 
 """
-    inverse_retract_nlsolve!(M::AbstractManifold, X, p, q, m)
+    inverse_retract_nlsolve!(M::AbstractManifold, X, p, q, m::NLSolveInverseRetraction)
 
 computes the mutating variant of the [`NLSolveInverseRetraction`](@ref) `m`.
 """
-inverse_retract_nlsolve!(M::AbstractManifold, X, p, q, m)
+inverse_retract_nlsolve!(M::AbstractManifold, X, p, q, m::NLSolveInverseRetraction)
 
 function inverse_retract_nlsolve! end
 
@@ -490,13 +496,18 @@ function _inverse_retract(M::AbstractManifold, p, q, ::SoftmaxInverseRetraction)
     return inverse_retract_softmax(M, p, q)
 end
 """
-    inverse_retract_embedded(M::AbstractManifold, p, q, m)
+    inverse_retract_embedded(M::AbstractManifold, p, q, m::AbstractInverseRetractionMethod)
 
 computes the allocating variant of the [`EmbeddedInverseRetraction`](@ref) using
 the [`AbstractInverseRetractionMethod`](@ref) `m` in the embedding (see [`get_embedding`](@ref))
 and projecting the result back.
 """
-function inverse_retract_embedded(M::AbstractManifold, p, q, m)
+function inverse_retract_embedded(
+    M::AbstractManifold,
+    p,
+    q,
+    m::AbstractInverseRetractionMethod,
+)
     return project(
         M,
         p,
@@ -561,12 +572,12 @@ function inverse_retract_qr(M::AbstractManifold, p, q)
     return inverse_retract_qr!(M, X, p, q)
 end
 """
-    inverse_retract_nlsolve(M::AbstractManifold, p, q, m)
+    inverse_retract_nlsolve(M::AbstractManifold, p, q, m::NLSolveInverseRetraction)
 
 computes the allocating variant of the [`NLSolveInverseRetraction`](@ref) `m`,
 which by default allocates and calls [`inverse_retract_nlsolve!`](@ref).
 """
-function inverse_retract_nlsolve(M::AbstractManifold, p, q, m)
+function inverse_retract_nlsolve(M::AbstractManifold, p, q, m::NLSolveInverseRetraction)
     X = allocate_result(M, inverse_retract, p, q)
     return inverse_retract_nlsolve!(M, X, p, q, m)
 end
@@ -637,13 +648,13 @@ function _retract!(M::AbstractManifold, q, p, X, ::PadeRetraction{n}) where {n}
 end
 
 """
-    retract_embedded!(M::AbstractManifold, X, p, q, m)
+    retract_embedded!(M::AbstractManifold, X, p, q, m::AbstractRetractionMethod)
 
 computes the mutating variant of the [`EmbeddedRetraction`](@ref) using
 the [`AbstractRetractionMethod`](@ref) `m` in the embedding (see [`get_embedding`](@ref))
 and projecting the result back.
 """
-function retract_embedded!(M::AbstractManifold, q, p, X, m)
+function retract_embedded!(M::AbstractManifold, q, p, X, m::AbstractRetractionMethod)
     return project!(
         M,
         q,
@@ -667,11 +678,18 @@ function retract_caley!(M::AbstractManifold, q, p, X)
 end
 
 """
-    retract_exp_ode!(M::AbstractManifold, q, p, X, m, B)
+    retract_exp_ode!(M::AbstractManifold, q, p, X, m::AbstractRetractionMethod, B::AbstractBasis)
 
 computes the mutating variant of the [`ODEExponentialRetraction`](@ref)`(m, B)`.
 """
-retract_exp_ode!(M::AbstractManifold, q, p, X, m, B)
+retract_exp_ode!(
+    M::AbstractManifold,
+    q,
+    p,
+    X,
+    m::AbstractRetractionMethod,
+    B::AbstractBasis,
+)
 
 function retract_exp_ode! end
 
@@ -776,13 +794,13 @@ function _retract(M::AbstractManifold, p, X, ::PadeRetraction{n}) where {n}
     return retract_pade(M, p, X, n)
 end
 """
-    retract_embedded(M::AbstractManifold, p, X, m)
+    retract_embedded(M::AbstractManifold, p, X, m::AbstractRetractionMethod)
 
 computes the allocating variant of the [`EmbeddedRetraction`](@ref) using
 the [`AbstractRetractionMethod`](@ref) `m` in the embedding (see [`get_embedding`](@ref))
 and projecting the result back.
 """
-function retract_embedded(M::AbstractManifold, p, X, m)
+function retract_embedded(M::AbstractManifold, p, X, m::AbstractRetractionMethod)
     return project(
         M,
         retract(
@@ -824,12 +842,18 @@ function retract_qr(M::AbstractManifold, p, X)
     return retract_qr!(M, q, p, X)
 end
 """
-    retract_exp_ode(M::AbstractManifold, p, q, m, B)
+    retract_exp_ode(M::AbstractManifold, p, q, m::AbstractRetractionMethod, B::AbstractBasis)
 
 computes the allocating variant of the [`ODEExponentialRetraction`](@ref)`(m,B)`,
 which by default allocates and calls [`retract_exp_ode!`](@ref ManifoldsBase.retract_exp_ode!).
 """
-function retract_exp_ode(M::AbstractManifold, p, X, m, B)
+function retract_exp_ode(
+    M::AbstractManifold,
+    p,
+    X,
+    m::AbstractRetractionMethod,
+    B::AbstractBasis,
+)
     q = allocate_result(M, retract, p, X)
     return retract_exp_ode!(M, q, p, X, m, B)
 end

--- a/src/vector_transport.jl
+++ b/src/vector_transport.jl
@@ -515,22 +515,22 @@ function _vector_transport_along(M::AbstractManifold, p, X, c, ::ProjectionTrans
     return vector_transport_along_project(M, p, X, c)
 end
 @doc raw"""
-    vector_transport_along_project(M::AbstractManifold, p, X, c)
+    vector_transport_along_project(M::AbstractManifold, p, X, c::AbstractVector)
 
 Compute the vector transport of `X` from ``T_p\mathcal M`` along the curve `c`
 using a projection.
 """
-function vector_transport_along_project(M::AbstractManifold, p, X, c)
+function vector_transport_along_project(M::AbstractManifold, p, X, c::AbstractVector)
     Y = allocate_result(M, vector_transport_along, X, p)
     return vector_transport_along_project!(M, Y, p, X, c)
 end
 @doc raw"""
-    vector_transport_along_project!(M::AbstractManifold, Y, p, X, c)
+    vector_transport_along_project!(M::AbstractManifold, Y, p, X, c::AbstractVector)
 
 Compute the vector transport of `X` from ``T_p\mathcal M`` along the curve `c`
 using a projection. The result is computed in place of `Y`.
 """
-vector_transport_along_project!(M::AbstractManifold, Y, p, X, c)
+vector_transport_along_project!(M::AbstractManifold, Y, p, X, c::AbstractVector)
 
 function vector_transport_along_project! end
 

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -72,7 +72,16 @@ end
 ManifoldsBase.retract_polar!(::DefaultManifold, q, p, X) = (q .= p .+ X)
 ManifoldsBase.retract_project!(::DefaultManifold, q, p, X) = (q .= p .+ X)
 ManifoldsBase.retract_qr!(::DefaultManifold, q, p, X) = (q .= p .+ X)
-ManifoldsBase.retract_exp_ode!(::DefaultManifold, q, p, X, m, B) = (q .= p .+ X)
+function ManifoldsBase.retract_exp_ode!(
+    ::DefaultManifold,
+    q,
+    p,
+    X,
+    m::AbstractRetractionMethod,
+    B::ManifoldsBase.AbstractBasis,
+)
+    return (q .= p .+ X)
+end
 ManifoldsBase.retract_pade!(::DefaultManifold, q, p, X, i) = (q .= p .+ X)
 ManifoldsBase.retract_softmax!(::DefaultManifold, q, p, X) = (q .= p .+ X)
 ManifoldsBase.get_embedding(M::DefaultManifold) = M # dummy embedding
@@ -80,8 +89,24 @@ ManifoldsBase.inverse_retract_polar!(::DefaultManifold, Y, p, q) = (Y .= q .- p)
 ManifoldsBase.inverse_retract_project!(::DefaultManifold, Y, p, q) = (Y .= q .- p)
 ManifoldsBase.inverse_retract_qr!(::DefaultManifold, Y, p, q) = (Y .= q .- p)
 ManifoldsBase.inverse_retract_softmax!(::DefaultManifold, Y, p, q) = (Y .= q .- p)
-ManifoldsBase.inverse_retract_nlsolve!(::DefaultManifold, Y, p, q, m) = (Y .= q .- p)
-ManifoldsBase.vector_transport_along_project!(::DefaultManifold, Y, p, X, c) = (Y .= X)
+function ManifoldsBase.inverse_retract_nlsolve!(
+    ::DefaultManifold,
+    Y,
+    p,
+    q,
+    m::NLSolveInverseRetraction,
+)
+    return (Y .= q .- p)
+end
+function ManifoldsBase.vector_transport_along_project!(
+    ::DefaultManifold,
+    Y,
+    p,
+    X,
+    c::AbstractVector,
+)
+    return (Y .= X)
+end
 
 
 Base.getindex(x::MatrixVectorTransport, i) = x.m[:, i]


### PR DESCRIPTION
I've put some bounds on types in a few methods. We may also need a few more methods for basis-related function forwarding but I'll think a bit more how to introduce them.