### PR TITLE
Small adjustment to showing cached bases

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.2"
+version = "0.13.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -957,13 +957,14 @@ function show(
     ::MIME"text/plain",
     B::CachedBasis{𝔽,T,D},
 ) where {𝔽,T<:AbstractBasis,D}
+    vectors = _get_vectors(B)
     print(
         io,
-        "$(T()) with $(length(_get_vectors(B))) basis vector$(length(_get_vectors(B)) == 1 ? "" : "s"):",
+        "Cached basis of type $T with $(length(vectors)) basis vector$(length(vectors) == 1 ? "" : "s"):",
     )
     return _show_basis_vector_range_noheader(
         io,
-        _get_vectors(B);
+        vectors;
         max_vectors = 4,
         pre = "  ",
         sym = " E",

--- a/test/bases.jl
+++ b/test/bases.jl
@@ -377,7 +377,7 @@ DiagonalizingBasisProxy() = DiagonalizingOrthonormalBasis([1.0, 0.0, 0.0])
         pb2 = get_basis(M, x, B2)
 
         test_basis_string = """
-        DefaultOrthonormalBasis(ℝ) with 6 basis vectors:
+        Cached basis of type $(sprint(show, typeof(DefaultOrthonormalBasis()))) with 6 basis vectors:
          E1 =
           2×3 $(sprint(show, Matrix{Float64})):
            1.0  0.0  0.0
@@ -438,7 +438,7 @@ DiagonalizingBasisProxy() = DiagonalizingOrthonormalBasis([1.0, 0.0, 0.0])
         x = reshape(Float64[1], (1, 1, 1))
         pb = get_basis(M, x, DefaultOrthonormalBasis())
         @test sprint(show, "text/plain", pb) == """
-        DefaultOrthonormalBasis(ℝ) with 1 basis vector:
+        Cached basis of type $(sprint(show, typeof(DefaultOrthonormalBasis()))) with 1 basis vector:
          E1 =
           1×1×1 $(sprint(show, Array{Float64,3})):
           [:, :, 1] =


### PR DESCRIPTION
I've been slightly annoyed by diagonalizing basis on tangent bundle not being printed correctly (it's incorrect anyway but it's a different issue) and I think it would make sense to stop relying on being able to do `T()` here. This is one way to fix the issue, probably a better one would be storing object of type `T` in `CachedBasis` itself -- I can change that if you prefer it @kellertuer .