### PR TITLE
Introduce a default for embed/embed! and retraction by projection

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.3"
+version = "0.13.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -262,6 +262,8 @@ Additionally, `embed` includes changing data representation, if applicable, i.e.
 if the points on `M` are not represented in the same way as points on the embedding,
 the representation is changed accordingly.
 
+The default is set in such a way that memory is allocated and `embed!(M, q, p)` is called.
+
 See also: [`EmbeddedManifold`](@ref), [`project`](@ref project(M::AbstractManifold,p))
 """
 function embed(M::AbstractManifold, p)
@@ -280,13 +282,17 @@ Additionally, `embed` might include changing data representation, if applicable,
 if points on `M` are not represented in the same way as their counterparts in the embedding,
 the representation is changed accordingly.
 
+The default is set in such a way that it assumes that the points on `M` are represented in
+their embedding (for example like the unit vectors in a space to represent the sphere) and
+hence embedding in the identity by default.
+
 If you have more than one embedding, see [`EmbeddedManifold`](@ref) for defining a second
 embedding. If your point `p` is already represented in some embedding,
 see [`AbstractDecoratorManifold`](@ref) how you can avoid reimplementing code from the embedded manifold
 
 See also: [`EmbeddedManifold`](@ref), [`project!`](@ref project!(M::AbstractManifold, q, p))
 """
-embed!(M::AbstractManifold, q, p)
+embed!(M::AbstractManifold, q, p) = copyto!(M, q, p)
 
 """
     embed(M::AbstractManifold, p, X)
@@ -298,6 +304,8 @@ is given. Not implementing this function means, there is no proper embedding for
 Additionally, `embed` might include changing data representation, if applicable, i.e.
 if tangent vectors on `M` are not represented in the same way as their counterparts in the
 embedding, the representation is changed accordingly.
+
+The default is set in such a way that memory is allocated and `embed!(M, Y, p. X)` is called.
 
 If you have more than one embedding, see [`EmbeddedManifold`](@ref) for defining a second
 embedding. If your tangent vector `X` is already represented in some embedding,
@@ -325,9 +333,13 @@ the representation is changed accordingly. This is the case for example for Lie 
 when tangent vectors are represented in the Lie algebra. The embedded tangents are then in
 the tangent spaces of the embedded base points.
 
+The default is set in such a way that it assumes that the points on `M` are represented in
+their embedding (for example like the unit vectors in a space to represent the sphere) and
+hence embedding also for tangent vectors is the identity by default.
+
 See also: [`EmbeddedManifold`](@ref), [`project!`](@ref project!(M::AbstractManifold, Y, p, X))
 """
-embed!(M::AbstractManifold, Y, p, X)
+embed!(M::AbstractManifold, Y, p, X) = copyto!(M, Y, p, X)
 
 @doc raw"""
     injectivity_radius(M::AbstractManifold)
@@ -427,7 +439,7 @@ function is_point(M::AbstractManifold, p, throw_error = false; kwargs...)
 end
 
 """
-    is_vector(M::AbstractManifold, p, X, throw_error = false; check_base_point=true, kwargs...)
+    is_vector(M::AbstractManifold, p, X, throw_error = false, check_base_point=true; kwargs...)
 
 Return whether `X` is a valid tangent vector at point `p` on the [`AbstractManifold`](@ref) `M`.
 Returns either `true` or `false`.

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -709,10 +709,7 @@ computes the mutating variant of the [`ProjectionRetraction`](@ref).
 By default this [`porject!`](@ref)s `X` onto the manifold (in place of `q`)
 after [`embed!`](@ref)ing `X`.
 """
-retract_project!(M::AbstractManifold, q, p, X) = project!(M, q, embed(M, p, X))
-# Note that we have to use embed (not embed!) since we do not have memory to store this embedded value in
-
-
+retract_project!(M::AbstractManifold, q, p, X)
 
 function retract_project! end
 

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -706,8 +706,6 @@ function retract_pade! end
     retract_project!(M::AbstractManifold, q, p, X)
 
 computes the mutating variant of the [`ProjectionRetraction`](@ref).
-By default this [`project`](@ref)s `X` onto the manifold (in place of `q`)
-after [`embed!`](@ref)ing `X`.
 """
 retract_project!(M::AbstractManifold, q, p, X)
 

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -706,8 +706,13 @@ function retract_pade! end
     retract_project!(M::AbstractManifold, q, p, X)
 
 computes the mutating variant of the [`ProjectionRetraction`](@ref).
+By default this [`porject!`](@ref)s `X` onto the manifold (in place of `q`)
+after [`embed!`](@ref)ing `X`.
 """
-retract_project!(M::AbstractManifold, q, p, X)
+retract_project!(M::AbstractManifold, q, p, X) = project!(M, q, embed(M, p, X))
+# Note that we have to use embed (not embed!) since we do not have memory to store this embedded value in
+
+
 
 function retract_project! end
 

--- a/src/vector_transport.jl
+++ b/src/vector_transport.jl
@@ -1012,7 +1012,8 @@ Compute a vector transport by projecting ``X\in T_p\mathcal M`` onto the tangent
 space ``T_q\mathcal M`` at ``q`` in place of `Y`.
 """
 function vector_transport_to_project!(M::AbstractManifold, Y, p, X, q)
-    return project!(M, Y, q, X)
+    # Note that we have to use embed (not embed!) since we do not have memory to store this embedded value in
+    return project!(M, Y, q, embed(M, p, X))
 end
 
 

--- a/test/decorator_traits.jl
+++ b/test/decorator_traits.jl
@@ -85,11 +85,11 @@ ManifoldsBase.representation_size(::NonDecoratorManifold) = (2,)
     Y = similar(X)
     @test ManifoldsBase.check_size(M, p) === nothing
     @test ManifoldsBase.check_size(M, p, X) === nothing
-    # Ambiguous since not implemented
-    @test_throws MethodError embed(M, p)
-    @test_throws MethodError embed!(M, q, p)
-    @test_throws MethodError embed(M, p, X)
-    @test_throws MethodError embed!(M, Y, p, X)
+    # default to identity
+    @test embed(M, p) == p
+    @test embed!(M, q, p) == p
+    @test embed(M, p, X) == X
+    @test embed!(M, Y, p, X) == X
     # the following is implemented but passes to the second and hence fails
     @test_throws MethodError exp(M, p, X)
     @test_throws MethodError exp!(M, q, p, X)

--- a/test/empty_manifold.jl
+++ b/test/empty_manifold.jl
@@ -93,14 +93,15 @@ struct NotImplementedInverseRetraction <: AbstractInverseRetractionMethod end
     @test_throws MethodError exp(M, [0.0], [0.0])
     @test_throws MethodError exp(M, [0.0], [0.0], 0.0)
 
-    @test_throws MethodError embed!(M, p, [0])
-    @test_throws MethodError embed!(M, [0], [0])
-    @test_throws MethodError embed(M, [0])
+    @test_throws MethodError embed!(M, p, [0]) # no copy for NoPoint p
+    @test embed!(M, [0], [0]) == [0]
+    @test embed(M, [0]) == [0]
 
-    @test_throws MethodError embed!(M, v, p, [0.0])
-    @test_throws MethodError embed!(M, [0], [0], [0])
-    @test_throws MethodError embed(M, [0], [0])
-    @test_throws MethodError embed(M, [0.0], [0.0])
+    # Identity
+    @test_throws MethodError embed!(M, v, p, [0.0]) # no copyto
+    @test embed!(M, [0], [0], [0]) == [0]
+    @test_throws MethodError embed(M, [0], v) # no copyto
+    @test embed(M, [0.0], [0.0]) == [0.0]
 
 
     @test_throws MethodError log!(M, v, p, p)


### PR DESCRIPTION
update the default for vector transport by projection, which now can also include a embed (since we have a default).