### PR TITLE
Default for getting ONB is pushed down in call chain

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.4"
+version = "0.13.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/DefaultManifold.jl
+++ b/src/DefaultManifold.jl
@@ -22,25 +22,25 @@ embed!(::DefaultManifold, Y, p, X) = copyto!(Y, X)
 
 exp!(::DefaultManifold, q, p, X) = (q .= p .+ X)
 
-function get_basis_orthonormal(::DefaultManifold, p, N)
+function get_basis_orthonormal(::DefaultManifold, p, N::RealNumbers)
     return CachedBasis(
         DefaultOrthonormalBasis(N),
         [_euclidean_basis_vector(p, i) for i in eachindex(p)],
     )
 end
-function get_basis_orthogonal(::DefaultManifold, p, N)
+function get_basis_orthogonal(::DefaultManifold, p, N::RealNumbers)
     return CachedBasis(
         DefaultOrthogonalBasis(N),
         [_euclidean_basis_vector(p, i) for i in eachindex(p)],
     )
 end
-function get_basis_default(::DefaultManifold, p, N)
+function get_basis_default(::DefaultManifold, p, N::RealNumbers)
     return CachedBasis(
         DefaultBasis(N),
         [_euclidean_basis_vector(p, i) for i in eachindex(p)],
     )
 end
-function get_basis_diagonalizing(M::DefaultManifold, p, B)
+function get_basis_diagonalizing(M::DefaultManifold, p, B::DiagonalizingOrthonormalBasis)
     vecs = get_vectors(M, p, get_basis(M, p, DefaultOrthonormalBasis()))
     eigenvalues = zeros(real(eltype(p)), manifold_dimension(M))
     return CachedBasis(B, DiagonalizingBasisData(B.frame_direction, eigenvalues, vecs))

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -379,18 +379,6 @@ function get_basis(M::AbstractManifold, p, B::AbstractBasis; kwargs...)
     return _get_basis(M, p, B; kwargs...)
 end
 
-function _get_basis(
-    M::AbstractManifold,
-    p,
-    B::DefaultOrthonormalBasis{<:Any,TangentSpaceType};
-    kwargs...,
-)
-    dim = number_of_coordinates(M, B)
-    return CachedBasis(
-        B,
-        [get_vector(M, p, [ifelse(i == j, 1, 0) for j in 1:dim], B) for i in 1:dim],
-    )
-end
 function _get_basis(::AbstractManifold, ::Any, B::CachedBasis)
     return B
 end
@@ -456,7 +444,14 @@ function get_basis_diagonalizing end
 function _get_basis(M::AbstractManifold, p, B::DefaultOrthonormalBasis)
     return get_basis_orthonormal(M, p, number_system(B))
 end
-function get_basis_orthonormal end
+function get_basis_orthonormal(M::AbstractManifold, p, N::AbstractNumbers; kwargs...)
+    B = DefaultOrthonormalBasis(N)
+    dim = number_of_coordinates(M, B)
+    return CachedBasis(
+        B,
+        [get_vector(M, p, [ifelse(i == j, 1, 0) for j in 1:dim], B) for i in 1:dim],
+    )
+end
 
 @doc raw"""
     get_coordinates(M::AbstractManifold, p, X, B::AbstractBasis)

--- a/test/bases.jl
+++ b/test/bases.jl
@@ -80,17 +80,21 @@ end
 function ManifoldsBase.get_basis_orthonormal(
     ::DefaultManifold,
     p::NonBroadcastBasisThing,
-    𝔽,
+    𝔽::RealNumbers,
 )
     return CachedBasis(
-        B,
+        DefaultOrthonormalBasis(𝔽),
         [
             NonBroadcastBasisThing(ManifoldsBase._euclidean_basis_vector(p.v, i)) for
             i in eachindex(p.v)
         ],
     )
 end
-function ManifoldsBase.get_basis_orthogonal(::DefaultManifold, p::NonBroadcastBasisThing, 𝔽)
+function ManifoldsBase.get_basis_orthogonal(
+    ::DefaultManifold,
+    p::NonBroadcastBasisThing,
+    𝔽::RealNumbers,
+)
     return CachedBasis(
         DefaultOrthogonalBasis(𝔽),
         [


### PR DESCRIPTION
I've discovered this while investigating one of coverage failures in Manifolds.jl -- we fall back to the default too early and implementations for specific manifolds are skipped.