### PR TITLE
Improve error message for embedded manifold is_point/is_vector

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.5"
+version = "0.13.6"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -603,7 +603,7 @@ export AbstractPowerManifold, PowerManifold
 export AbstractPowerRepresentation,
     NestedPowerRepresentation, NestedReplacingPowerRepresentation
 
-export OutOfInjectivityRadiusError
+export OutOfInjectivityRadiusError, ManifoldDomainError
 
 export AbstractRetractionMethod,
     ApproximateInverseRetraction,

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -650,7 +650,7 @@ export CachedBasis,
     ProjectedOrthonormalBasis,
     VeeOrthogonalBasis
 
-export CompositeManifoldError, ComponentManifoldError
+export CompositeManifoldError, ComponentManifoldError, ManifoldDomainError
 
 export allocate,
     angle,

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -322,7 +322,7 @@ function is_point(
         return false
     end
     mpe = check_point(get_embedding(M, p), embed(M, p); kwargs...)
-    if mpe !=M nothing
+    if mpe !== nothing
         wrapped_error = ManifoldDomainError(
             "$p is not a point on $M because it is not a valid point in its embedding: ",
             mpe,

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -1,5 +1,5 @@
 #
-# Base passons
+# Base pass-ons
 #
 manifold_dimension(M::AbstractDecoratorManifold) = manifold_dimension(base_manifold(M))
 
@@ -321,9 +321,15 @@ function is_point(
         te && throw(es)
         return false
     end
-    # this throws if te=true
-    ep = is_point(get_embedding(M, p), embed(M, p), te; kwargs...)
-    !ep && return false # otherwise if we get here with ep=false, end with false
+    mpe = check_point(get_embedding(M, p), embed(M, p); kwargs...)
+    if mpe !=M nothing
+        wrapped_error = ManifoldDomainError(
+            "$p is not a point on $M because it is not a valid point in its embedding: ",
+            mpe,
+        )
+        te && throw(wrapped_error)
+        return false
+    end
     mpe = check_point(M, p; kwargs...)
     mpe === nothing && return true
     te && throw(mpe)
@@ -363,8 +369,15 @@ function is_vector(
         return false
     end
     # Check vector in embedding
-    ev = is_vector(get_embedding(M, p), embed(M, p), embed(M, p, X), te, cbp; kwargs...)
-    (!ev && !te) && return false # if te, the line before throws an error, otherwise we end with false early here
+    mpe = check_vector(get_embedding(M, p), embed(M, p), embed(M, p, X); kwargs...)
+    if mpe !== nothing
+        wrapped_error = ManifoldDomainError(
+            "$X is not a tangent vector to $p on $M because it is not a valid tangent vector in its embedding: ",
+            mpe,
+        )
+        te && throw(wrapped_error)
+        return false
+    end
     # Check (additional) local stuff
     mtve = check_vector(M, p, X; kwargs...)
     mtve === nothing && return true

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -138,14 +138,28 @@ end
 @trait_function check_size(M::AbstractDecoratorManifold, p)
 # Embedded
 function check_size(::TraitList{IsEmbeddedManifold}, M::AbstractDecoratorManifold, p)
-    return check_size(get_embedding(M, p), p)
+    mpe = check_size(get_embedding(M, p), embed(M, p))
+    if mpe !== nothing
+        return ManifoldDomainError(
+            "$p is not a point on $M because it is not a valid point in its embedding: ",
+            mpe,
+        )
+    end
+    return nothing
 end
 
 # Introduce Deco Trait | automatic foward | fallback
 @trait_function check_size(M::AbstractDecoratorManifold, p, X)
 # Embedded
 function check_size(::TraitList{IsEmbeddedManifold}, M::AbstractDecoratorManifold, p, X)
-    return check_size(get_embedding(M, p), p, X)
+    mpe = check_size(get_embedding(M, p), embed(M, p), embed(M, p, X))
+    if mpe !== nothing
+        return ManifoldDomainError(
+            "$X is not a tangent vector to $p on $M because it is not a valid tangent vector in its embedding: ",
+            mpe,
+        )
+    end
+    return nothing
 end
 
 # Introduce Deco Trait | automatic foward | fallback

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -141,7 +141,7 @@ function check_size(::TraitList{IsEmbeddedManifold}, M::AbstractDecoratorManifol
     mpe = check_size(get_embedding(M, p), embed(M, p))
     if mpe !== nothing
         return ManifoldDomainError(
-            "$p is not a point on $M because it is not a valid point in its embedding: ",
+            "$p is not a point on $M because it is not a valid point in its embedding.",
             mpe,
         )
     end
@@ -155,7 +155,7 @@ function check_size(::TraitList{IsEmbeddedManifold}, M::AbstractDecoratorManifol
     mpe = check_size(get_embedding(M, p), embed(M, p), embed(M, p, X))
     if mpe !== nothing
         return ManifoldDomainError(
-            "$X is not a tangent vector to $p on $M because it is not a valid tangent vector in its embedding: ",
+            "$X is not a tangent vector to $p on $M because it is not a valid tangent vector in its embedding.",
             mpe,
         )
     end
@@ -338,7 +338,7 @@ function is_point(
     mpe = check_point(get_embedding(M, p), embed(M, p); kwargs...)
     if mpe !== nothing
         wrapped_error = ManifoldDomainError(
-            "$p is not a point on $M because it is not a valid point in its embedding: ",
+            "$p is not a point on $M because it is not a valid point in its embedding.",
             mpe,
         )
         te && throw(wrapped_error)
@@ -386,7 +386,7 @@ function is_vector(
     mpe = check_vector(get_embedding(M, p), embed(M, p), embed(M, p, X); kwargs...)
     if mpe !== nothing
         wrapped_error = ManifoldDomainError(
-            "$X is not a tangent vector to $p on $M because it is not a valid tangent vector in its embedding: ",
+            "$X is not a tangent vector to $p on $M because it is not a valid tangent vector in its embedding.",
             mpe,
         )
         te && throw(wrapped_error)

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -92,6 +92,6 @@ struct ManifoldDomainError{E} <: Exception where {E<:Exception}
 end
 
 function Base.showerror(io::IO, ex::ManifoldDomainError)
-    print(io, ex.outer_text)
+    print(io, "$(ex.outer_text)\n")
     return showerror(io, ex.error)
 end

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -93,5 +93,5 @@ end
 
 function Base.showerror(io::IO, ex::ManifoldDomainError)
     print(io, ex.outer_text)
-    return print(io, ex.error)
+    return showerror(io, ex.error)
 end

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -78,3 +78,20 @@ An error thrown when a function (for example [`log`](@ref)arithmic map or
 [`inverse_retract`](@ref)) is given arguments outside of its [`injectivity_radius`](@ref).
 """
 struct OutOfInjectivityRadiusError <: Exception end
+
+"""
+    ManifoldDomainError{<:Exception} <: Exception
+
+An error to represent a nested (Domain) error on a manifold, for example
+if a point or tangent vector is invalid because its representation in some
+embedding is already invalid.
+"""
+struct ManifoldDomainError{E} <: Exception where {E<:Exception}
+    outer_text::String
+    error::E
+end
+
+function Base.showerror(io::IO, ex::ManifoldDomainError)
+    print(io, ex.outer_text)
+    return print(io, ex.error)
+end

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -92,6 +92,6 @@ struct ManifoldDomainError{E} <: Exception where {E<:Exception}
 end
 
 function Base.showerror(io::IO, ex::ManifoldDomainError)
-    print(io, "$(ex.outer_text)\n")
+    print(io, "ManifoldDomainError: $(ex.outer_text)\n")
     return showerror(io, ex.error)
 end

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -1,7 +1,7 @@
 using ManifoldsBase
 using ManifoldsBase:
     @manifold_element_forwards, @manifold_vector_forwards, @default_manifold_fallbacks
-using ManifoldsBase: DefaultManifold, AbstractNumbers
+using ManifoldsBase: DefaultManifold, AbstractNumbers, RealNumbers, ComplexNumbers
 import ManifoldsBase:
     number_eltype,
     check_point,
@@ -147,6 +147,9 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
     rm = ManifoldsBase.ExponentialRetraction()
     irm = ManifoldsBase.LogarithmicInverseRetraction()
 
+    # Representation sizes not equal
+    @test ManifoldsBase.check_size(M, zeros(3, 3)) isa DomainError
+    @test ManifoldsBase.check_size(M, zeros(3), zeros(3, 3)) isa DomainError
     rm2 = CustomDefinedRetraction()
     rm3 = CustomUndefinedRetraction()
 

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -193,12 +193,11 @@ ManifoldsBase.decorated_manifold(::FallbackManifold) = DefaultManifold(3)
         @test is_point(M, [1 0.1 0.1], true)
         @test_throws DomainError is_point(M, [-1, 0, 0], true) #wrong dim (3,1)
         @test !is_point(M, [-1, 0, 0])
-        @test_throws DomainError is_point(M, [1, 0.1], true) # size
+        @test_throws ManifoldDomainError is_point(M, [1, 0.1], true) # size
         @test is_point(M, [1 0 0], true)
         @test !is_point(M, [-1 0 0]) # right size but <0 1st
         @test_throws DomainError is_point(M, [-1 0 0], true) # right size but <0 1st
-        @test_throws DomainError is_vector(M, [1, 0, 0], [1 0 0], true)
-        @test_throws DomainError is_vector(M, [1 0 0], [1], true) # right point, wrong size vector
+        @test_throws ManifoldDomainError is_vector(M, [1 0 0], [1], true) # right point, wrong size vector
         @test !is_vector(M, [1 0 0], [1])
         @test_throws DomainError is_vector(M, [1 0 0], [-1 0 0], true) # right point, vec 1st <0
         @test !is_vector(M, [1 0 0], [-1 0 0])
@@ -212,10 +211,10 @@ ManifoldsBase.decorated_manifold(::FallbackManifold) = DefaultManifold(3)
         X = q - p
         @test ManifoldsBase.check_size(M, p) === nothing
         @test ManifoldsBase.check_size(M, p, X) === nothing
-        @test ManifoldsBase.check_size(M, [1, 2]) isa DomainError
-        @test ManifoldsBase.check_size(M, [1 2 3 4]) isa DomainError
-        @test ManifoldsBase.check_size(M, p, [1, 2]) isa DomainError
-        @test ManifoldsBase.check_size(M, p, [1 2 3 4]) isa DomainError
+        @test ManifoldsBase.check_size(M, [1, 2]) isa ManifoldDomainError
+        @test ManifoldsBase.check_size(M, [1 2 3 4]) isa ManifoldDomainError
+        @test ManifoldsBase.check_size(M, p, [1, 2]) isa ManifoldDomainError
+        @test ManifoldsBase.check_size(M, p, [1 2 3 4]) isa ManifoldDomainError
         @test embed(M, p) == p
         pE = similar(p)
         embed!(M, pE, p)

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -208,7 +208,8 @@ ManifoldsBase.decorated_manifold(::FallbackManifold) = DefaultManifold(3)
         @test is_point(M, [1 0.1 0.1], true)
         @test_throws DomainError is_point(M, [-1, 0, 0], true) #wrong dim (3,1)
         @test !is_point(M, [-1, 0, 0])
-        @test_throws ManifoldDomainError is_point(M, [1, 0.1], true) # size
+        @test_throws ManifoldDomainError is_point(M, [1, 0.1], true) # size (from embedding)
+        @test !is_point(M, [1, 0.1])
         @test is_point(M, [1 0 0], true)
         @test !is_point(M, [-1 0 0]) # right size but <0 1st
         @test_throws DomainError is_point(M, [-1 0 0], true) # right size but <0 1st

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -29,4 +29,8 @@ using Test
     @test repr(e5) == "CompositeManifoldError([$(repr(e2)), $(repr(e2)), ])"
     s5 = sprint(showerror, e5)
     @test s5 == "CompositeManifoldError: $(s2)\n\n...and $(length(eV)-1) more error(s).\n"
+
+    e6 = ManifoldDomainError("A ", e)
+    s6 = sprint(showerror, e6)
+    @test s6 == "A DomainError with 1.0:\nNorm not zero."
 end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -30,7 +30,7 @@ using Test
     s5 = sprint(showerror, e5)
     @test s5 == "CompositeManifoldError: $(s2)\n\n...and $(length(eV)-1) more error(s).\n"
 
-    e6 = ManifoldDomainError("A ", e)
+    e6 = ManifoldDomainError("A.", e)
     s6 = sprint(showerror, e6)
-    @test s6 == "A DomainError with 1.0:\nNorm not zero."
+    @test s6 == "ManifoldDomainError: A.\nDomainError with 1.0:\nNorm not zero."
 end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -32,5 +32,5 @@ using Test
 
     e6 = ManifoldDomainError("A.", e)
     s6 = sprint(showerror, e6)
-    @test s6 == "ManifoldDomainError: A.\nDomainError with 1.0:\nNorm not zero."
+    @test s6 == "ManifoldDomainError: A.\n$(s1)"
 end


### PR DESCRIPTION
(Yet another small update) to have nicer error messages for the case of embedded manifolds when the check for validity in the embedding (already) fails.

I am not sure whether we might have missed a `check_size` in the embedding here (that is one thing that is not done in the newly used `check_` compare to the old `is_`), and we still have to check for test coverage.