### PR TITLE
Make get_vectors a trait function

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: julia-actions/julia-buildpkg@latest
       - uses: julia-actions/julia-runtest@latest
       - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
+      - uses: codecov/codecov-action@v2
         with:
           fail_ci_if_error: false
         if: ${{ matrix.os =='ubuntu-latest' }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.8"
+version = "0.13.9"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -224,6 +224,9 @@ end
 # Introduce Deco Trait | automatic foward | fallback
 @trait_function get_vector!(M::AbstractDecoratorManifold, Y, p, c, B::AbstractBasis)
 
+# Introduce Deco Trait | automatic foward | fallback
+@trait_function get_vectors(M::AbstractDecoratorManifold, p, B::AbstractBasis)
+
 @trait_function injectivity_radius(M::AbstractDecoratorManifold)
 function injectivity_radius(
     ::TraitList{IsIsometricEmbeddedManifold},


### PR DESCRIPTION
This is needed to fix basis support for group-decorated manifolds.