### PR TITLE
Faster `get_basis_orthonormal`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.13"
+version = "0.13.14"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -452,10 +452,7 @@ function get_basis_orthonormal(M::AbstractManifold, p, N::AbstractNumbers; kwarg
     p1 = one(Eltp)
     return CachedBasis(
         B,
-        [
-            get_vector(M, p, [ifelse(i == j, p1, p0) for j in 1:dim], B) for
-            i in 1:dim
-        ],
+        [get_vector(M, p, [ifelse(i == j, p1, p0) for j in 1:dim], B) for i in 1:dim],
     )
 end
 
@@ -721,7 +718,13 @@ end
 end
 function get_vector_orthonormal! end
 
-@inline function _get_vector!(M::AbstractManifold, Y, p, c, B::DiagonalizingOrthonormalBasis)
+@inline function _get_vector!(
+    M::AbstractManifold,
+    Y,
+    p,
+    c,
+    B::DiagonalizingOrthonormalBasis,
+)
     return get_vector_diagonalizing!(M, Y, p, c, B)
 end
 function get_vector_diagonalizing! end

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -448,10 +448,12 @@ function get_basis_orthonormal(M::AbstractManifold, p, N::AbstractNumbers; kwarg
     B = DefaultOrthonormalBasis(N)
     dim = number_of_coordinates(M, B)
     Eltp = number_eltype(p)
+    p0 = zero(Eltp)
+    p1 = one(Eltp)
     return CachedBasis(
         B,
         [
-            get_vector(M, p, [ifelse(i == j, one(Eltp), zero(Eltp)) for j in 1:dim], B) for
+            get_vector(M, p, [ifelse(i == j, p1, p0) for j in 1:dim], B) for
             i in 1:dim
         ],
     )
@@ -621,28 +623,28 @@ requires either a dual basis or the cached basis to be selfdual, for example ort
 
 See also: [`get_coordinates`](@ref), [`get_basis`](@ref)
 """
-function get_vector(M::AbstractManifold, p, c, B::AbstractBasis)
+@inline function get_vector(M::AbstractManifold, p, c, B::AbstractBasis)
     return _get_vector(M, p, c, B)
 end
 
-function _get_vector(M::AbstractManifold, p, c, B::VeeOrthogonalBasis)
+@inline function _get_vector(M::AbstractManifold, p, c, B::VeeOrthogonalBasis)
     return get_vector_vee(M, p, c, number_system(B))
 end
-function get_vector_vee(M::AbstractManifold, p, c, N)
+@inline function get_vector_vee(M::AbstractManifold, p, c, N)
     return get_vector(M, p, c, DefaultOrthogonalBasis(N))
 end
 
-function _get_vector(M::AbstractManifold, p, c, B::DefaultBasis)
+@inline function _get_vector(M::AbstractManifold, p, c, B::DefaultBasis)
     return get_vector_default(M, p, c, number_system(B))
 end
-function get_vector_default(M::AbstractManifold, p, c, N)
+@inline function get_vector_default(M::AbstractManifold, p, c, N)
     return get_vector(M, p, c, DefaultOrthogonalBasis(N))
 end
 
-function _get_vector(M::AbstractManifold, p, c, B::DefaultOrthogonalBasis)
+@inline function _get_vector(M::AbstractManifold, p, c, B::DefaultOrthogonalBasis)
     return get_vector_orthogonal(M, p, c, number_system(B))
 end
-function get_vector_orthogonal(M::AbstractManifold, p, c, N)
+@inline function get_vector_orthogonal(M::AbstractManifold, p, c, N)
     return get_vector_orthonormal(M, p, c, N)
 end
 
@@ -655,7 +657,7 @@ function get_vector_orthonormal(M::AbstractManifold, p, c, N)
     return get_vector!(M, Y, p, c, B)
 end
 
-function _get_vector(M::AbstractManifold, p, c, B::DiagonalizingOrthonormalBasis)
+@inline function _get_vector(M::AbstractManifold, p, c, B::DiagonalizingOrthonormalBasis)
     return get_vector_diagonalizing(M, p, c, B)
 end
 function get_vector_diagonalizing(
@@ -668,7 +670,7 @@ function get_vector_diagonalizing(
     return get_vector!(M, Y, p, c, B)
 end
 
-function _get_vector(M::AbstractManifold, p, c, B::CachedBasis)
+@inline function _get_vector(M::AbstractManifold, p, c, B::CachedBasis)
     return get_vector_cached(M, p, c, B)
 end
 _get_vector_cache_broadcast(::Any) = Val(true)
@@ -691,40 +693,40 @@ function get_vector_cached(M::AbstractManifold, p, X, B::CachedBasis)
     end
     return Xt
 end
-function get_vector!(M::AbstractManifold, Y, p, c, B::AbstractBasis)
+@inline function get_vector!(M::AbstractManifold, Y, p, c, B::AbstractBasis)
     return _get_vector!(M, Y, p, c, B)
 end
 
-function _get_vector!(M::AbstractManifold, Y, p, c, B::VeeOrthogonalBasis)
+@inline function _get_vector!(M::AbstractManifold, Y, p, c, B::VeeOrthogonalBasis)
     return get_vector_vee!(M, Y, p, c, number_system(B))
 end
-get_vector_vee!(M, Y, p, c, N) = get_vector!(M, Y, p, c, DefaultOrthogonalBasis(N))
+@inline get_vector_vee!(M, Y, p, c, N) = get_vector!(M, Y, p, c, DefaultOrthogonalBasis(N))
 
-function _get_vector!(M::AbstractManifold, Y, p, c, B::DefaultBasis)
+@inline function _get_vector!(M::AbstractManifold, Y, p, c, B::DefaultBasis)
     return get_vector_default!(M, Y, p, c, number_system(B))
 end
-function get_vector_default!(M::AbstractManifold, Y, p, c, N)
+@inline function get_vector_default!(M::AbstractManifold, Y, p, c, N)
     return get_vector!(M, Y, p, c, DefaultOrthogonalBasis(N))
 end
 
-function _get_vector!(M::AbstractManifold, Y, p, c, B::DefaultOrthogonalBasis)
+@inline function _get_vector!(M::AbstractManifold, Y, p, c, B::DefaultOrthogonalBasis)
     return get_vector_orthogonal!(M, Y, p, c, number_system(B))
 end
-function get_vector_orthogonal!(M::AbstractManifold, Y, p, c, N)
+@inline function get_vector_orthogonal!(M::AbstractManifold, Y, p, c, N)
     return get_vector!(M, Y, p, c, DefaultOrthonormalBasis(N))
 end
 
-function _get_vector!(M::AbstractManifold, Y, p, c, B::DefaultOrthonormalBasis)
+@inline function _get_vector!(M::AbstractManifold, Y, p, c, B::DefaultOrthonormalBasis)
     return get_vector_orthonormal!(M, Y, p, c, number_system(B))
 end
 function get_vector_orthonormal! end
 
-function _get_vector!(M::AbstractManifold, Y, p, c, B::DiagonalizingOrthonormalBasis)
+@inline function _get_vector!(M::AbstractManifold, Y, p, c, B::DiagonalizingOrthonormalBasis)
     return get_vector_diagonalizing!(M, Y, p, c, B)
 end
 function get_vector_diagonalizing! end
 
-function _get_vector!(M::AbstractManifold, Y, p, c, B::CachedBasis)
+@inline function _get_vector!(M::AbstractManifold, Y, p, c, B::CachedBasis)
     return get_vector_cached!(M, Y, p, c, B)
 end
 function get_vector_cached!(M::AbstractManifold, Y, p, X, B::CachedBasis)


### PR DESCRIPTION
This is much faster `get_basis_orthonormal` (constants weren't properly propagated). Also some inlines, at least one of them was needed but other should be harmless anyway, or maybe even helpful in some rare cases..