### PR TITLE
Better default for get_basis coordinate eltype

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.15"
+version = "0.13.16"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -319,6 +319,21 @@ function combine_allocation_promotion_functions(::typeof(identity), ::typeof(com
     return complex
 end
 
+"""
+    coordinate_eltype(M::AbstractManifold{M𝔽}, p, 𝔽::AbstractNumbers) where {M𝔽}
+
+Get the element type for 𝔽-field coordinates of the tangent space at a point `p` from
+manifold `M`. This default assumes that usually complex bases of complex manifolds have
+real coordinates but it can be overridden by a more specific method.
+"""
+@inline function coordinate_eltype(::AbstractManifold{M𝔽}, p, 𝔽::AbstractNumbers) where {M𝔽}
+    if M𝔽 === 𝔽
+        return real(number_eltype(p))
+    else
+        return number_eltype(p)
+    end
+end
+
 @doc raw"""
     dual_basis(M::AbstractManifold, p, B::AbstractBasis)
 
@@ -445,25 +460,10 @@ function _get_basis(M::AbstractManifold, p, B::DefaultOrthonormalBasis)
     return get_basis_orthonormal(M, p, number_system(B))
 end
 
-"""
-    _get_basis_eltype(M::AbstractManifold{M𝔽}, p, 𝔽::AbstractNumbers) where {M𝔽}
-
-Get the element type for 𝔽-field coordinates of the tangent space at a point `p` from
-manifold `M`. This default assumes that usually complex bases of complex manifolds have
-real coordinates but it can be overridden by a more specific method.
-"""
-@inline function _get_basis_eltype(::AbstractManifold{M𝔽}, p, 𝔽::AbstractNumbers) where {M𝔽}
-    if M𝔽 === 𝔽
-        return real(number_eltype(p))
-    else
-        return number_eltype(p)
-    end
-end
-
 function get_basis_orthonormal(M::AbstractManifold, p, N::AbstractNumbers; kwargs...)
     B = DefaultOrthonormalBasis(N)
     dim = number_of_coordinates(M, B)
-    Eltp = _get_basis_eltype(M, p, N)
+    Eltp = coordinate_eltype(M, p, N)
     p0 = zero(Eltp)
     p1 = one(Eltp)
     return CachedBasis(

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -444,10 +444,26 @@ function get_basis_diagonalizing end
 function _get_basis(M::AbstractManifold, p, B::DefaultOrthonormalBasis)
     return get_basis_orthonormal(M, p, number_system(B))
 end
+
+"""
+    _get_basis_eltype(M::AbstractManifold{M𝔽}, p, 𝔽::AbstractNumbers) where {M𝔽}
+
+Get the element type for 𝔽-field coordinates of the tangent space at a point `p` from
+manifold `M`. This default assumes that usually complex bases of complex manifolds have
+real coordinates but it can be overridden by a more specific method.
+"""
+@inline function _get_basis_eltype(::AbstractManifold{M𝔽}, p, 𝔽::AbstractNumbers) where {M𝔽}
+    if M𝔽 === 𝔽
+        return real(number_eltype(p))
+    else
+        return number_eltype(p)
+    end
+end
+
 function get_basis_orthonormal(M::AbstractManifold, p, N::AbstractNumbers; kwargs...)
     B = DefaultOrthonormalBasis(N)
     dim = number_of_coordinates(M, B)
-    Eltp = number_eltype(p)
+    Eltp = _get_basis_eltype(M, p, N)
     p0 = zero(Eltp)
     p1 = one(Eltp)
     return CachedBasis(

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -624,9 +624,9 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
         p = [1.0im, 2.0im, -1.0im]
         CB = get_basis(MC, p, DefaultOrthonormalBasis(ManifoldsBase.ℂ))
         @test CB.data isa Vector{Vector{ComplexF64}}
-        @test ManifoldsBase._get_basis_eltype(MC, p, ManifoldsBase.ℂ) === Float64
-        @test ManifoldsBase._get_basis_eltype(MC, p, ManifoldsBase.ℝ) === ComplexF64
-        CBR = get_basis(MC, p, DefaultOrthonormalBasis(ManifoldsBase.ℝ))
+        @test ManifoldsBase.coordinate_eltype(MC, p, ManifoldsBase.ℂ) === Float64
+        @test ManifoldsBase.coordinate_eltype(MC, p, ManifoldsBase.ℝ) === ComplexF64
+        CBR = get_basis(MC, p, DefaultOrthonormalBasis())
         @test CBR.data == [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
     end
     @testset "Show methods" begin

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -610,7 +610,7 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
         @test parallel_transport_direction!(M, Y, p, X, X) == X
         @test parallel_transport_along!(M, Y, p, X, []) == X
     end
-    @testset "DefaultManifold  and ONB" begin
+    @testset "DefaultManifold and ONB" begin
         M = ManifoldsBase.DefaultManifold(3)
         p = [1.0f0, 0.0f0, 0.0f0]
         CB = get_basis(M, p, DefaultOrthonormalBasis())
@@ -618,6 +618,13 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
         @test CB.data isa Vector{Vector{Float32}}
         @test CB.data ==
               [[1.0f0, 0.0f0, 0.0f0], [0.0f0, 1.0f0, 0.0f0], [0.0f0, 0.0f0, 1.0f0]]
+
+        # test complex point -> real coordinates
+        MC = ManifoldsBase.DefaultManifold(3; field = ManifoldsBase.ℂ)
+        p = [1.0im, 2.0im, -1.0im]
+        CB = get_basis(MC, p, DefaultOrthonormalBasis(ManifoldsBase.ℂ))
+        @test CB.data isa Vector{Vector{ComplexF64}}
+        @test ManifoldsBase._get_basis_eltype(MC, p, ManifoldsBase.ℂ) === Float64
     end
     @testset "Show methods" begin
         @test repr(CayleyRetraction()) == "CayleyRetraction()"

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -625,6 +625,9 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
         CB = get_basis(MC, p, DefaultOrthonormalBasis(ManifoldsBase.ℂ))
         @test CB.data isa Vector{Vector{ComplexF64}}
         @test ManifoldsBase._get_basis_eltype(MC, p, ManifoldsBase.ℂ) === Float64
+        @test ManifoldsBase._get_basis_eltype(MC, p, ManifoldsBase.ℝ) === ComplexF64
+        CBR = get_basis(MC, p, DefaultOrthonormalBasis(ManifoldsBase.ℝ))
+        @test CBR.data == [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
     end
     @testset "Show methods" begin
         @test repr(CayleyRetraction()) == "CayleyRetraction()"


### PR DESCRIPTION
Just a small enhancement to make it possible to use this `get_basis` for quaternionic unitary matrices (see https://github.com/JuliaManifolds/Manifolds.jl/pull/511).