### PR TITLE
Introduce the default_method functions for Power manifolds.

### DIFF
--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -368,6 +368,36 @@ function copyto!(M::PowerManifoldNested, Y, p, X)
 end
 
 @doc raw"""
+    default_retraction_method(M::PowerManifold)
+
+uses the default retraction method of the internal `M.manifold` also in defaults of
+functions defined for the power manifold, meaning that this is useed elementwise.
+"""
+function default_retraction_method(M::PowerManifold)
+    return default_retraction_method(M.manifold)
+end
+
+@doc raw"""
+    default_inverse_retraction_method(M::PowerManifold)
+
+uses the default inverse retraction method of the internal `M.manifold` also in defaults of
+functions defined for the power manifold, meaning that this is useed elementwise.
+"""
+function default_inverse_retraction_method(M::PowerManifold)
+    return default_inverse_retraction_method(M.manifold)
+end
+
+@doc raw"""
+    default_vector_transport_method(M::PowerManifold)
+
+uses the default vector transport method of the internal `M.manifold` also in defaults of
+functions defined for the power manifold, meaning that this is useed elementwise.
+"""
+function default_vector_transport_method(M::PowerManifold)
+    return default_vector_transport_method(M.manifold)
+end
+
+@doc raw"""
     distance(M::AbstractPowerManifold, p, q)
 
 Compute the distance between `q` and `p` on an [`AbstractPowerManifold`](@ref),

--- a/test/power.jl
+++ b/test/power.jl
@@ -30,6 +30,9 @@ struct TestArrayRepresentation <: AbstractPowerRepresentation end
         @test ManifoldsBase.check_power_size(O, p) isa DomainError
         @test ManifoldsBase.check_power_size(N, p, X) === nothing
         @test ManifoldsBase.check_power_size(O, p, X) isa DomainError
+        @test default_inverse_retraction_method(M) == default_inverse_retraction_method(N)
+        @test default_retraction_method(M) == default_retraction_method(N)
+        @test default_vector_transport_method(M) == default_vector_transport_method(N)
     end
 
     @testset "PowerManifold and allocation with empty representation size" begin


### PR DESCRIPTION
This PR introduces default method functions (retraction, inverse retraction, vector transport) for `PowerManifold`.