### PR TITLE
Add shooting method

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.19"
+version = "0.13.20"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/retractions.md
+++ b/docs/src/retractions.md
@@ -29,7 +29,7 @@ The general interface looks as follows.
 
 ```@autodocs
 Modules = [ManifoldsBase]
-Pages = ["retractions.jl"]
+Pages = ["retractions.jl", "shooting.jl"]
 Order = [:function]
 Private = false
 Public = true
@@ -42,7 +42,7 @@ specifies a type. The following ones are available.
 
 ```@autodocs
 Modules = [ManifoldsBase]
-Pages = ["retractions.jl"]
+Pages = ["retractions.jl", "shooting.jl"]
 Order = [:type]
 ```
 
@@ -52,7 +52,7 @@ While you should always add your documentation to [`retract`](@ref) or [`retract
 
 ```@autodocs
 Modules = [ManifoldsBase]
-Pages = ["retractions.jl"]
+Pages = ["retractions.jl", "shooting.jl"]
 Order = [:function]
 Public = false
 Private = true

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -644,6 +644,7 @@ end
 include("errors.jl")
 include("parallel_transport.jl")
 include("vector_transport.jl")
+include("shooting.jl")
 include("vector_spaces.jl")
 include("point_vector_fallbacks.jl")
 include("nested_trait.jl")
@@ -676,6 +677,7 @@ export AbstractRetractionMethod,
     PadeRetraction,
     PolarRetraction,
     ProjectionRetraction,
+    ShootingInverseRetraction,
     SoftmaxRetraction
 
 export AbstractInverseRetractionMethod,

--- a/src/shooting.jl
+++ b/src/shooting.jl
@@ -64,7 +64,7 @@ function inverse_retract_shooting!(
     gap = norm(M, p, X)
     gap < m.tolerance && return X
     T = real(Base.promote_type(number_eltype(X), number_eltype(p), number_eltype(q)))
-    transport_grid = range(one(T), zero(T); length=m.num_transport_points)[2:(end - 1)]
+    transport_grid = range(one(T), zero(T); length = m.num_transport_points)[2:(end - 1)]
     ΔX = allocate(X)
     ΔXnew = tX = allocate(ΔX)
     retr_tX = allocate_result(M, retract, p, X)

--- a/src/shooting.jl
+++ b/src/shooting.jl
@@ -1,0 +1,91 @@
+"""
+    ShootingInverseRetraction <: ApproximateInverseRetraction
+
+Approximating the inverse of a retraction using the shooting method.
+
+This implementation of the shooting method works by using another inverse retraction to form
+the first guess of the vector. This guess is updated by shooting the vector, guessing the
+vector pointing from the shooting result to the target point, and transporting this vector
+update back to the initial point on a discretized grid. This process is repeated until the
+norm of the vector update falls below a specified tolerance or the maximum number of
+iterations is reached.
+
+# Fields
+- `retraction::AbstractRetractionMethod`: The retraction whose inverse is approximated.
+- `initial_inverse_retraction::AbstractInverseRetractionMethod`: The inverse retraction used
+    to form the initial guess of the vector.
+- `vector_transport::AbstractVectorTransportMethod`: The vector transport used to transport
+    the initial guess of the vector.
+- `num_transport_points::Int`: The number of discretization points used for vector
+    transport in the shooting method. 2 is the minimum number of points, including just the
+    endpoints.
+- `tolerance::Real`: The tolerance for the shooting method.
+- `max_iterations::Int`: The maximum number of iterations for the shooting method.
+"""
+struct ShootingInverseRetraction{
+    R<:AbstractRetractionMethod,
+    IR<:AbstractInverseRetractionMethod,
+    VT<:AbstractVectorTransportMethod,
+    T<:Real,
+} <: ApproximateInverseRetraction
+    retraction::R
+    initial_inverse_retraction::IR
+    vector_transport::VT
+    num_transport_points::Int
+    tolerance::T
+    max_iterations::Int
+end
+
+function _inverse_retract!(M::AbstractManifold, X, p, q, m::ShootingInverseRetraction)
+    return inverse_retract_shooting!(M, X, p, q, m)
+end
+function _inverse_retract(M::AbstractManifold, p, q, m::ShootingInverseRetraction)
+    return inverse_retract_shooting(M, p, q, m)
+end
+
+"""
+    inverse_retract_shooting(M::AbstractManifold, p, q, m::ShootingInverseRetraction)
+
+Approximate the inverse of a retraction using the shooting method.
+"""
+function inverse_retract_shooting(M::AbstractManifold, p, q, m::ShootingInverseRetraction)
+    X = allocate_result(M, inverse_retract, p, q)
+    return inverse_retract_shooting!(M, X, p, q, m)
+end
+
+function inverse_retract_shooting!(
+    M::AbstractManifold,
+    X,
+    p,
+    q,
+    m::ShootingInverseRetraction,
+)
+    inverse_retract!(M, X, p, q, m.initial_inverse_retraction)
+    gap = norm(M, p, X)
+    gap < m.tolerance && return X
+    T = real(Base.promote_type(number_eltype(X), number_eltype(p), number_eltype(q)))
+    transport_grid = range(one(T), zero(T); length=m.num_transport_points)[2:(end - 1)]
+    ΔX = allocate(X)
+    ΔXnew = tX = allocate(ΔX)
+    retr_tX = allocate_result(M, retract, p, X)
+    if m.num_transport_points > 2
+        retr_tX_new = allocate_result(M, retract, p, X)
+    end
+    iteration = 1
+    while (gap > m.tolerance) && (iteration < m.max_iterations)
+        retract!(M, retr_tX, p, X, m.retraction)
+        inverse_retract!(M, ΔX, retr_tX, q, m.initial_inverse_retraction)
+        gap = norm(M, retr_tX, ΔX)
+        for t in transport_grid
+            tX .= t .* X
+            retract!(M, retr_tX_new, p, tX, m.retraction)
+            vector_transport_to!(M, ΔXnew, retr_tX, ΔX, retr_tX_new, m.vector_transport)
+            # realias storage
+            retr_tX, retr_tX_new, ΔX, ΔXnew, tX = retr_tX_new, retr_tX, ΔXnew, ΔX, ΔX
+        end
+        vector_transport_to!(M, ΔXnew, retr_tX, ΔX, p, m.vector_transport)
+        X .+= ΔXnew
+        iteration += 1
+    end
+    return X
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,6 +30,7 @@ using ManifoldsBase
     include("complex_manifold.jl")
     include("validation_manifold.jl")
     include("embedded_manifold.jl")
+    include("test_sphere.jl")
     include("power.jl")
     include("domain_errors.jl")
     include("vector_transport.jl")

--- a/test/test_sphere.jl
+++ b/test/test_sphere.jl
@@ -21,7 +21,7 @@ end
 
 ManifoldsBase.inner(::TestSphere, p, X, Y) = dot(X, Y)
 
-function ManifoldsBase.inverse_retract_project!(::TestSphere, X, p, q)
+function ManifoldsBase.inverse_retract_project!(M::TestSphere, X, p, q)
     X .= q .- p
     project!(M, X, p, X)
     return X

--- a/test/test_sphere.jl
+++ b/test/test_sphere.jl
@@ -68,7 +68,7 @@ end
                     10_000,
                 )
                 Y = inverse_retract(M, p, q, inverse_retraction)
-                @test isapprox(M, p, Y, X; atol = 1e-6)
+                @test isapprox(M, p, Y, X; atol = 1e-3)
             end
         end
     end

--- a/test/test_sphere.jl
+++ b/test/test_sphere.jl
@@ -69,6 +69,9 @@ end
                 )
                 Y = inverse_retract(M, p, q, inverse_retraction)
                 @test isapprox(M, p, Y, X; atol = 1e-3)
+                Y2 = similar(Y)
+                inverse_retract!(M, Y2, p, q, inverse_retraction)
+                @test isapprox(M, p, Y2, Y)
             end
         end
     end

--- a/test/test_sphere.jl
+++ b/test/test_sphere.jl
@@ -1,0 +1,75 @@
+using LinearAlgebra
+using ManifoldsBase
+using ManifoldsBase: ℝ, ℂ, DefaultManifold
+using Test
+
+# minimal sphere implementation for testing more complicated manifolds
+struct TestSphere{N,𝔽} <: AbstractManifold{𝔽} end
+TestSphere(N::Int, 𝔽 = ℝ) = TestSphere{N,𝔽}()
+
+ManifoldsBase.representation_size(::TestSphere{N}) where {N} = (N + 1,)
+
+function ManifoldsBase.exp!(::TestSphere, q, p, X)
+    θ = norm(X)
+    if θ == 0
+        copyto!(q, p)
+    else
+        q .= p .* cos(θ) .+ X .* sin(θ) ./ θ
+    end
+    return q
+end
+
+ManifoldsBase.inner(::TestSphere, p, X, Y) = dot(X, Y)
+
+function ManifoldsBase.inverse_retract_project!(::TestSphere, X, p, q)
+    X .= q .- p
+    project!(M, X, p, X)
+    return X
+end
+
+function ManifoldsBase.log!(::TestSphere, X, p, q)
+    cosθ = clamp(real(dot(p, q)), -1, 1)
+    X .= q .- p .* cosθ
+    nrmX = norm(X)
+    if nrmX > 0
+        X .*= acos(cosθ) / nrmX
+    end
+    return X
+end
+
+function ManifoldsBase.project!(::TestSphere, q, p)
+    q .= p ./ norm(p)
+    return q
+end
+
+function ManifoldsBase.project!(::TestSphere, Y, p, X)
+    Y .= X .- p .* real(dot(p, X))
+    return Y
+end
+
+@testset "TestSphere" begin
+    @testset "ShootingInverseRetraction" begin
+        vector_transports =
+            [ScaledVectorTransport(ProjectionTransport()), PoleLadderTransport()]
+        num_transport_points = [2, 4]
+        @testset for M in [TestSphere(2), TestSphere(3, ℂ)]
+            T = number_system(M) === ℝ ? Float64 : ComplexF64
+            p = project(M, randn(T, representation_size(M)))
+            X = project(M, p, randn(T, representation_size(M)))
+            X ./= norm(M, p, X)
+            q = exp(M, p, X)
+            @testset for vector_transport in vector_transports, ntp in num_transport_points
+                inverse_retraction = ShootingInverseRetraction(
+                    ExponentialRetraction(),
+                    ProjectionInverseRetraction(),
+                    vector_transport,
+                    ntp,
+                    1e-9,
+                    10_000,
+                )
+                Y = inverse_retract(M, p, q, inverse_retraction)
+                @test isapprox(M, p, Y, X; atol = 1e-6)
+            end
+        end
+    end
+end


### PR DESCRIPTION
This PR ports the shooting method code from https://github.com/JuliaManifolds/Manifolds.jl/pull/535. It slightly redesigns the API to better align with how the other (inverse) retractions are implemented here. The code lives in its own file, since it needs access to the `AbstractVectorTransport` type, which isn't available until after `retractions.jl` is imported.

I'm not certain the best way to test this. I could use `DefaultManifold`, but Euclidean is too easy of a case. Is there anything like a minimal sphere implementation in the test suite?