### PR TITLE
Introduce a `RetractionWithKeywords` to specify / fix keywords on Layer 1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.22"
+version = "0.13.23"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -677,6 +677,7 @@ export AbstractRetractionMethod,
     PadeRetraction,
     PolarRetraction,
     ProjectionRetraction,
+    RetractionWithKeywords,
     ShootingInverseRetraction,
     SoftmaxRetraction
 

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -691,6 +691,7 @@ export AbstractInverseRetractionMethod,
     PadeInverseRetraction,
     PolarInverseRetraction,
     ProjectionInverseRetraction,
+    InverseRetractionWithKeywords,
     SoftmaxInverseRetraction
 
 export AbstractVectorTransportMethod,

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -702,7 +702,8 @@ export AbstractVectorTransportMethod,
     ScaledVectorTransport,
     SchildsLadderTransport,
     VectorTransportDirection,
-    VectorTransportTo
+    VectorTransportTo,
+    VectorTransportWithKeywords
 
 export CachedBasis,
     DefaultBasis,

--- a/src/parallel_transport.jl
+++ b/src/parallel_transport.jl
@@ -17,13 +17,13 @@ its covariant derivative ``\frac{\mathrm{D}}{\mathrm{d}t}Z`` is zero. Note that 
 
 Then the parallel transport is given by ``Z(1)``.
 """
-function parallel_transport_along(M::AbstractManifold, p, X, c::AbstractVector)
+function parallel_transport_along(M::AbstractManifold, p, X, c::AbstractVector; kwargs...)
     Y = allocate_result(M, vector_transport_along, X, p)
-    return parallel_transport_along!(M, Y, p, X, c)
+    return parallel_transport_along!(M, Y, p, X, c; kwargs...)
 end
 
-function parallel_transport_direction!(M::AbstractManifold, Y, p, X, d)
-    return parallel_transport_to!(M, Y, p, X, exp(M, p, d))
+function parallel_transport_direction!(M::AbstractManifold, Y, p, X, d; kwargs...)
+    return parallel_transport_to!(M, Y, p, X, exp(M, p, d); kwargs...)
 end
 
 @doc raw"""
@@ -34,8 +34,8 @@ i.e. the * the unique geodesic ``c(t)=γ_{p,X}(t)`` from ``γ_{p,d}(0)=p`` into 
 
 By default this function calls [`parallel_transport_to`](@ref)`(M, p, X, q)`, where ``q=\exp_pX``.
 """
-function parallel_transport_direction(M::AbstractManifold, p, X, d)
-    return parallel_transport_to(M, p, X, exp(M, p, d))
+function parallel_transport_direction(M::AbstractManifold, p, X, d; kwargs...)
+    return parallel_transport_to(M, p, X, exp(M, p, d); kwargs...)
 end
 
 function parallel_transport_to! end
@@ -46,7 +46,7 @@ function parallel_transport_to! end
 Compute the [`parallel_transport_along`](@ref) the curve ``c(t) = γ_{p,q}(t)``,
 i.e. the (assumed to be unique) [`geodesic`](@ref) connecting `p` and `q`, of the tangent vector `X`.
 """
-function parallel_transport_to(M::AbstractManifold, p, X, q)
+function parallel_transport_to(M::AbstractManifold, p, X, q; kwargs...)
     Y = allocate_result(M, vector_transport_to, X, p, q)
-    return parallel_transport_to!(M, Y, p, X, q)
+    return parallel_transport_to!(M, Y, p, X, q; kwargs...)
 end

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -135,14 +135,14 @@ struct QRRetraction <: AbstractRetractionMethod end
 Since retractions might have keywords, this type is a way to set them as an own type to be
 used as a specific retraction.
 Another reason for this type is that we dispatch on the retraction first and only the
-last layer would be implemented with keywords, so this way they can be passed down
+last layer would be implemented with keywords, so this way they can be passed down.
 
 ## Fields
 
 * `retraction` the retraction that is decorated with keywords
 * `kwargs` the keyword arguments
 
-Note that you can nest this type. Then the most outer specification of a keyword wins.
+Note that you can nest this type. Then the most outer specification of a keyword is used.
 
 ## Constructor
 
@@ -311,14 +311,14 @@ end
 Since inverse retractions might have keywords, this type is a way to set them as an own type to be
 used as a specific inverse retraction.
 Another reason for this type is that we dispatch on the inverse retraction first and only the
-last layer would be implemented with keywords, so this way they can be passed down
+last layer would be implemented with keywords, so this way they can be passed down.
 
 ## Fields
 
 * `inverse_retraction` the inverse retraction that is decorated with keywords
 * `kwargs` the keyword arguments
 
-Note that you can nest this type. Then the most outer specification of a keyword wins.
+Note that you can nest this type. Then the most outer specification of a keyword is used.
 
 ## Constructor
 

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -140,7 +140,7 @@ last layer would be implemented with keywords, so this way they can be passed do
 ## Fields
 
 * `retraction` the retraction that is decorated with keywords
-* `kwargs` th ekeyword arguments
+* `kwargs` the keyword arguments
 
 Note that you can nest this type. Then the most outer specification of a keyword wins.
 
@@ -306,17 +306,17 @@ end
 
 
 """
-    RetractionWithKeywords{R<:AbstractRetractionMethod,K} <: AbstractRetractionMethod
+    InverseRetractionWithKeywords{R<:AbstractRetractionMethod,K} <: AbstractRetractionMethod
 
-Since retractions might have keywords, this type is a way to set them as an own type to be
-used as a specific retraction.
-Another reason for this type is that we dispatch on the retraction first and only the
+Since inverse retractions might have keywords, this type is a way to set them as an own type to be
+used as a specific inverse retraction.
+Another reason for this type is that we dispatch on the inverse retraction first and only the
 last layer would be implemented with keywords, so this way they can be passed down
 
 ## Fields
 
-* `inverse_retraction` the retraction that is decorated with keywords
-* `kwargs` th ekeyword arguments
+* `inverse_retraction` the inverse retraction that is decorated with keywords
+* `kwargs` the keyword arguments
 
 Note that you can nest this type. Then the most outer specification of a keyword wins.
 
@@ -324,7 +324,7 @@ Note that you can nest this type. Then the most outer specification of a keyword
 
     InverseRetractionWithKeywords(m::T; kwargs...) where {T <: AbstractInverseRetractionMethod}
 
-Specify the subtype `T <: `[`AbstractRetractionMethod`](@ref) to have keywords `kwargs...`.
+Specify the subtype `T <: `[`AbstractInverseRetractionMethod`](@ref) to have keywords `kwargs...`.
 """
 struct InverseRetractionWithKeywords{T<:AbstractInverseRetractionMethod,K} <:
        AbstractInverseRetractionMethod

--- a/src/vector_transport.jl
+++ b/src/vector_transport.jl
@@ -524,7 +524,14 @@ function _vector_transport_along(
 )
     return vector_transport_along_diff(M, p, X, c, m.retraction; kwargs...)
 end
-function _vector_transport_along(M, p, X, c, m::VectorTransportWithKeywords; kwargs...)
+function _vector_transport_along(
+    M::AbstractManifold,
+    p,
+    X,
+    c,
+    m::VectorTransportWithKeywords;
+    kwargs...,
+)
     return _vector_transport_along(M, p, X, c, m.vector_transport; kwargs..., m.kwargs...)
 end
 
@@ -684,6 +691,26 @@ function _vector_transport_along!(
     kwargs...,
 )
     return vector_transport_along_project!(M, Y, p, X, c; kwargs...)
+end
+function _vector_transport_along!(
+    M::AbstractManifold,
+    Y,
+    p,
+    X,
+    c,
+    m::VectorTransportWithKeywords;
+    kwargs...,
+)
+    return _vector_transport_along!(
+        M,
+        Y,
+        p,
+        X,
+        c,
+        m.vector_transport;
+        kwargs...,
+        m.kwargs...,
+    )
 end
 
 @doc raw"""
@@ -894,7 +921,7 @@ function _vector_transport_direction(
     kwargs...,
 )
     r = default_retraction_method(M)
-    v = length(kwargs) > 0 ? VectorTransportWithKeywords(m, kwargs) : m
+    v = length(kwargs) > 0 ? VectorTransportWithKeywords(m; kwargs...) : m
     return vector_transport_to(M, p, X, retract(M, p, d, r), v)
 end
 function _vector_transport_direction(
@@ -906,7 +933,7 @@ function _vector_transport_direction(
     kwargs...,
 )
     mv =
-        length(kwargs) > 0 ? VectorTransportWithKeywords(m.vector_transport, kwargs) :
+        length(kwargs) > 0 ? VectorTransportWithKeywords(m.vector_transport; kwargs...) :
         m.vector_transport
     mr = m.retraction
     return vector_transport_to(M, p, X, retract(M, p, d, mr), mv)
@@ -934,7 +961,7 @@ function _vector_transport_direction(
         p,
         X,
         d,
-        m.vector_transport,
+        m.vector_transport;
         kwargs...,
         m.kwargs...,
     )
@@ -999,7 +1026,7 @@ function _vector_transport_direction!(
     kwargs...,
 )
     r = default_retraction_method(M)
-    v = length(kwargs) > 0 ? VectorTransportWithKeywords(m, kwargs) : m
+    v = length(kwargs) > 0 ? VectorTransportWithKeywords(m; kwargs...) : m
     return vector_transport_to!(M, Y, p, X, retract(M, p, d, r), v)
 end
 function _vector_transport_direction!(
@@ -1012,7 +1039,7 @@ function _vector_transport_direction!(
     kwargs...,
 )
     v =
-        length(kwargs) > 0 ? VectorTransportWithKeywords(m.vector_transport, kwargs) :
+        length(kwargs) > 0 ? VectorTransportWithKeywords(m.vector_transport; kwargs...) :
         m.vector_transport
     return vector_transport_to!(M, Y, p, X, retract(M, p, d, m.retraction), v)
 end
@@ -1097,7 +1124,7 @@ end
 function _vector_transport_to(M::AbstractManifold, p, X, q, m::VectorTransportTo; kwargs...)
     d = inverse_retract(M, p, q, m.inverse_retraction)
     v =
-        length(kwargs) > 0 ? VectorTransportWithKeywords(m.vector_transport, kwargs) :
+        length(kwargs) > 0 ? VectorTransportWithKeywords(m.vector_transport; kwargs...) :
         m.vector_transport
     return vector_transport_direction(M, p, X, d, v)
 end
@@ -1204,7 +1231,7 @@ function _vector_transport_to!(
     kwargs...,
 )
     d = inverse_retract(M, p, q, m.inverse_retraction)
-    return vector_transport_direction!(M, Y, p, X, d, m.vector_transport; kwargs...)
+    return _vector_transport_direction!(M, Y, p, X, d, m.vector_transport; kwargs...)
 end
 function _vector_transport_to!(
     M::AbstractManifold,
@@ -1299,7 +1326,7 @@ function _vector_transport_to!(
     m::ScaledVectorTransport;
     kwargs...,
 )
-    v = length(kwargs) > 0 ? VectorTransportWithKeywords(m.method, kwargs) : m.method
+    v = length(kwargs) > 0 ? VectorTransportWithKeywords(m.method; kwargs...) : m.method
     vector_transport_to!(M, Y, p, X, q, v)
     Y .*= norm(M, p, X) / norm(M, q, Y)
     return Y

--- a/src/vector_transport.jl
+++ b/src/vector_transport.jl
@@ -119,7 +119,6 @@ changed to an [`AbstractRetractionMethod`](@ref) `retraction` and an
     > Pennec, X: Parallel Transport with Pole Ladder: a Third Order Scheme in Affine
     > Connection Spaces which is Exact in Affine Symmetric Spaces.
     > arXiv: [1805.11436](https://arxiv.org/abs/1805.11436)
-
 """
 struct PoleLadderTransport{
     RT<:AbstractRetractionMethod,
@@ -207,7 +206,6 @@ changed to an [`AbstractRetractionMethod`](@ref) `retraction` and an
     > propagation. In: O’Raifeartaigh, L. (ed.) General Relativity: Papers in Honour of
     > J. L. Synge, pp. 63–84. Clarendon Press, Oxford (1972).
     > reprint doi: [10.1007/s10714-012-1353-4](https://doi.org/10.1007/s10714-012-1353-4)
-
 """
 struct SchildsLadderTransport{
     RT<:AbstractRetractionMethod,
@@ -280,6 +278,39 @@ struct VectorTransportTo{
             vector_transport,
         )
     end
+end
+
+"""
+    VectorTransportWithKeywords{V<:AbstractVectorTransportMethod, K} <: AbstractVectorTransportMethod
+
+Since vector transports might have keywords, this type is a way to set them as an own type to be
+used as a specific vector transport.
+Another reason for this type is that we dispatch on the vector transport first and only the
+last layer would be implemented with keywords, so this way they can be passed down.
+
+## Fields
+
+* `vector_transport` the vector transport that is decorated with keywords
+* `kwargs` the keyword arguments
+
+Note that you can nest this type. Then the most outer specification of a keyword wins.
+
+## Constructor
+
+    VectorTransportWithKeywords(m::T; kwargs...) where {T <: AbstractVectorTransportMethod}
+
+Specify the subtype `T <: `[`AbstractVectorTransportMethod`](@ref) to have keywords `kwargs...`.
+"""
+struct VectorTransportWithKeywords{T<:AbstractVectorTransportMethod,K} <:
+       AbstractVectorTransportMethod
+    vector_transport::T
+    kwargs::K
+end
+function VectorTransportWithKeywords(
+    m::T;
+    kwargs...,
+) where {T<:AbstractVectorTransportMethod}
+    return VectorTransportWithKeywords{T,typeof(kwargs)}(m, kwargs)
 end
 
 """
@@ -473,18 +504,30 @@ function vector_transport_along(
 )
     return _vector_transport_along(M, p, X, c, m)
 end
-function _vector_transport_along(M::AbstractManifold, p, X, c, ::ParallelTransport)
-    return parallel_transport_along(M, p, X, c)
+function _vector_transport_along(
+    M::AbstractManifold,
+    p,
+    X,
+    c,
+    ::ParallelTransport;
+    kwargs...,
+)
+    return parallel_transport_along(M, p, X, c; kwargs...)
 end
 function _vector_transport_along(
     M::AbstractManifold,
     p,
     X,
     c,
-    m::DifferentiatedRetractionVectorTransport,
+    m::DifferentiatedRetractionVectorTransport;
+    kwargs...,
 )
-    return vector_transport_along_diff(M, p, X, c, m.retraction)
+    return vector_transport_along_diff(M, p, X, c, m.retraction; kwargs...)
 end
+function _vector_transport_along(M, p, X, c, m::VectorTransportWithKeywords; kwargs...)
+    return _vector_transport_along(M, p, X, c, m.vector_transport; kwargs..., m.kwargs...)
+end
+
 @doc raw"""
     vector_transport_along_diff(M::AbstractManifold, p, X, c, m::AbstractRetractionMethod)
 
@@ -511,8 +554,15 @@ vector_transport_along_diff!(M::AbstractManifold, Y, p, X, c, m)
 
 function vector_transport_along_diff! end
 
-function _vector_transport_along(M::AbstractManifold, p, X, c, ::ProjectionTransport)
-    return vector_transport_along_project(M, p, X, c)
+function _vector_transport_along(
+    M::AbstractManifold,
+    p,
+    X,
+    c,
+    ::ProjectionTransport;
+    kwargs...,
+)
+    return vector_transport_along_project(M, p, X, c; kwargs...)
 end
 @doc raw"""
     vector_transport_along_project(M::AbstractManifold, p, X, c::AbstractVector)
@@ -520,9 +570,15 @@ end
 Compute the vector transport of `X` from ``T_p\mathcal M`` along the curve `c`
 using a projection.
 """
-function vector_transport_along_project(M::AbstractManifold, p, X, c::AbstractVector)
+function vector_transport_along_project(
+    M::AbstractManifold,
+    p,
+    X,
+    c::AbstractVector;
+    kwargs...,
+)
     Y = allocate_result(M, vector_transport_along, X, p)
-    return vector_transport_along_project!(M, Y, p, X, c)
+    return vector_transport_along_project!(M, Y, p, X, c; kwargs...)
 end
 @doc raw"""
     vector_transport_along_project!(M::AbstractManifold, Y, p, X, c::AbstractVector)
@@ -539,20 +595,22 @@ function _vector_transport_along(
     p,
     X,
     c::AbstractVector,
-    m::PoleLadderTransport,
+    m::PoleLadderTransport;
+    kwargs...,
 )
     Y = allocate_result(M, vector_transport_along, X, p)
-    return _vector_transport_along!(M, Y, p, X, c, m)
+    return _vector_transport_along!(M, Y, p, X, c, m; kwargs...)
 end
 function _vector_transport_along(
     M::AbstractManifold,
     p,
     X,
     c::AbstractVector,
-    m::SchildsLadderTransport,
+    m::SchildsLadderTransport;
+    kwargs...,
 )
     Y = allocate_result(M, vector_transport_along, X, p)
-    return _vector_transport_along!(M, Y, p, X, c, m)
+    return _vector_transport_along!(M, Y, p, X, c, m; kwargs...)
 end
 
 """
@@ -574,14 +632,21 @@ function vector_transport_along!(
     return _vector_transport_along!(M, Y, p, X, c, m)
 end
 
-function parallel_transport_along!(M::AbstractManifold, Y, p, X, c::AbstractVector)
+function parallel_transport_along!(
+    M::AbstractManifold,
+    Y,
+    p,
+    X,
+    c::AbstractVector;
+    kwargs...,
+)
     n = length(c)
     if n == 0
         copyto!(Y, X)
     else
-        parallel_transport_to!(M, Y, p, X, c[1])
+        parallel_transport_to!(M, Y, p, X, c[1]; kwargs...)
         for i in 1:(length(c) - 1)
-            parallel_transport_to!(M, Y, c[i], Y, c[i + 1])
+            parallel_transport_to!(M, Y, c[i], Y, c[i + 1]; kwargs...)
         end
     end
     return Y
@@ -593,9 +658,10 @@ function _vector_transport_along!(
     p,
     X,
     c::AbstractVector,
-    ::ParallelTransport,
+    ::ParallelTransport;
+    kwargs...,
 )
-    return parallel_transport_along!(M, Y, p, X, c)
+    return parallel_transport_along!(M, Y, p, X, c; kwargs...)
 end
 function _vector_transport_along!(
     M::AbstractManifold,
@@ -603,9 +669,10 @@ function _vector_transport_along!(
     p,
     X,
     c::AbstractVector,
-    m::DifferentiatedRetractionVectorTransport,
+    m::DifferentiatedRetractionVectorTransport;
+    kwargs...,
 )
-    return vector_transport_along_diff!(M, Y, p, X, c, m.retraction)
+    return vector_transport_along_diff!(M, Y, p, X, c, m.retraction; kwargs...)
 end
 function _vector_transport_along!(
     M::AbstractManifold,
@@ -613,9 +680,10 @@ function _vector_transport_along!(
     p,
     X,
     c::AbstractVector,
-    ::ProjectionTransport,
+    ::ProjectionTransport;
+    kwargs...,
 )
-    return vector_transport_along_project!(M, Y, p, X, c)
+    return vector_transport_along_project!(M, Y, p, X, c; kwargs...)
 end
 
 @doc raw"""
@@ -647,7 +715,8 @@ function _vector_transport_along!(
     p,
     X,
     c::AbstractVector,
-    m::PoleLadderTransport,
+    m::PoleLadderTransport;
+    kwargs...,
 )
     clen = length(c)
     if clen == 0
@@ -665,6 +734,7 @@ function _vector_transport_along!(
             Y;
             retraction = m.retraction,
             inverse_retraction = m.inverse_retraction,
+            kwargs...,
         )
         for i in 1:(clen - 1)
             # precompute mid point inplace
@@ -682,6 +752,7 @@ function _vector_transport_along!(
                 Y;
                 retraction = m.retraction,
                 inverse_retraction = m.inverse_retraction,
+                kwargs...,
             )
         end
         inverse_retract!(M, Y, c[clen], d, m.inverse_retraction)
@@ -717,7 +788,8 @@ function _vector_transport_along!(
     p,
     X,
     c::AbstractVector,
-    m::SchildsLadderTransport,
+    m::SchildsLadderTransport;
+    kwargs...,
 )
     clen = length(c)
     if clen == 0
@@ -735,6 +807,7 @@ function _vector_transport_along!(
             Y;
             retraction = m.retraction,
             inverse_retraction = m.inverse_retraction,
+            kwargs...,
         )
         for i in 1:(clen - 1)
             ci = c[i]
@@ -752,6 +825,7 @@ function _vector_transport_along!(
                 Y;
                 retraction = m.retraction,
                 inverse_retraction = m.inverse_retraction,
+                kwargs...,
             )
         end
         inverse_retract!(M, Y, c[clen], d, m.inverse_retraction)
@@ -816,28 +890,54 @@ function _vector_transport_direction(
     p,
     X,
     d,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M);
+    kwargs...,
 )
     r = default_retraction_method(M)
-    return vector_transport_to(M, p, X, retract(M, p, d, r), m)
+    v = length(kwargs) > 0 ? VectorTransportWithKeywords(m, kwargs) : m
+    return vector_transport_to(M, p, X, retract(M, p, d, r), v)
 end
 function _vector_transport_direction(
     M::AbstractManifold,
     p,
     X,
     d,
-    m::VectorTransportDirection,
+    m::VectorTransportDirection;
+    kwargs...,
 )
-    return vector_transport_to(M, p, X, retract(M, p, d, m.retraction), m.vector_transport)
+    mv =
+        length(kwargs) > 0 ? VectorTransportWithKeywords(m.vector_transport, kwargs) :
+        m.vector_transport
+    mr = m.retraction
+    return vector_transport_to(M, p, X, retract(M, p, d, mr), mv)
 end
 function _vector_transport_direction(
     M::AbstractManifold,
     p,
     X,
     d,
-    m::DifferentiatedRetractionVectorTransport{R},
+    m::DifferentiatedRetractionVectorTransport{R};
+    kwargs...,
 ) where {R<:AbstractRetractionMethod}
-    return vector_transport_direction_diff(M, p, X, d, m.retraction)
+    return vector_transport_direction_diff(M, p, X, d, m.retraction; kwargs...)
+end
+function _vector_transport_direction(
+    M::AbstractManifold,
+    p,
+    X,
+    d,
+    m::VectorTransportWithKeywords;
+    kwargs...,
+)
+    return _vector_transport_direction(
+        M,
+        p,
+        X,
+        d,
+        m.vector_transport,
+        kwargs...,
+        m.kwargs...,
+    )
 end
 @doc raw"""
     vector_transport_direction_diff(M::AbstractManifold, p, X, d, m::AbstractRetractionMethod)
@@ -850,15 +950,22 @@ function vector_transport_direction_diff(
     p,
     X,
     d,
-    r::AbstractRetractionMethod,
+    r::AbstractRetractionMethod;
+    kwargs...,
 )
     Y = allocate_result(M, vector_transport_direction, p, X, d)
-    return vector_transport_direction_diff!(M, Y, p, X, d, r)
+    return vector_transport_direction_diff!(M, Y, p, X, d, r; kwargs...)
 end
-function _vector_transport_direction(M::AbstractManifold, p, X, d, ::ParallelTransport)
-    return parallel_transport_direction(M, p, X, d)
+function _vector_transport_direction(
+    M::AbstractManifold,
+    p,
+    X,
+    d,
+    ::ParallelTransport;
+    kwargs...,
+)
+    return parallel_transport_direction(M, p, X, d; kwargs...)
 end
-
 
 """
     vector_transport_direction!(M::AbstractManifold, Y, p, X, d)
@@ -888,10 +995,12 @@ function _vector_transport_direction!(
     p,
     X,
     d,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M);
+    kwargs...,
 )
     r = default_retraction_method(M)
-    return vector_transport_to!(M, Y, p, X, retract(M, p, d, r), m)
+    v = length(kwargs) > 0 ? VectorTransportWithKeywords(m, kwargs) : m
+    return vector_transport_to!(M, Y, p, X, retract(M, p, d, r), v)
 end
 function _vector_transport_direction!(
     M::AbstractManifold,
@@ -899,16 +1008,13 @@ function _vector_transport_direction!(
     p,
     X,
     d,
-    m::VectorTransportDirection,
+    m::VectorTransportDirection;
+    kwargs...,
 )
-    return vector_transport_to!(
-        M,
-        Y,
-        p,
-        X,
-        retract(M, p, d, m.retraction),
-        m.vector_transport,
-    )
+    v =
+        length(kwargs) > 0 ? VectorTransportWithKeywords(m.vector_transport, kwargs) :
+        m.vector_transport
+    return vector_transport_to!(M, Y, p, X, retract(M, p, d, m.retraction), v)
 end
 function _vector_transport_direction!(
     M::AbstractManifold,
@@ -916,9 +1022,10 @@ function _vector_transport_direction!(
     p,
     X,
     d,
-    m::DifferentiatedRetractionVectorTransport,
+    m::DifferentiatedRetractionVectorTransport;
+    kwargs...,
 )
-    return vector_transport_direction_diff!(M, Y, p, X, d, m.retraction)
+    return vector_transport_direction_diff!(M, Y, p, X, d, m.retraction; kwargs...)
 end
 @doc raw"""
     vector_transport_direction_diff!(M::AbstractManifold, Y, p, X, d, m::AbstractRetractionMethod)
@@ -930,8 +1037,37 @@ vector_transport_direction_diff!(M, Y, p, X, d, m)
 
 function vector_transport_direction_diff! end
 
-function _vector_transport_direction!(M::AbstractManifold, Y, p, X, d, ::ParallelTransport)
-    return parallel_transport_direction!(M, Y, p, X, d)
+function _vector_transport_direction!(
+    M::AbstractManifold,
+    Y,
+    p,
+    X,
+    d,
+    ::ParallelTransport;
+    kwargs...,
+)
+    return parallel_transport_direction!(M, Y, p, X, d; kwargs...)
+end
+
+function _vector_transport_direction!(
+    M::AbstractManifold,
+    Y,
+    p,
+    X,
+    d,
+    m::VectorTransportWithKeywords;
+    kwargs...,
+)
+    return _vector_transport_direction!(
+        M,
+        Y,
+        p,
+        X,
+        d,
+        m.vector_transport;
+        kwargs...,
+        m.kwargs...,
+    )
 end
 
 @doc raw"""
@@ -958,30 +1094,44 @@ function vector_transport_to(
 )
     return _vector_transport_to(M, p, X, q, m)
 end
-function _vector_transport_to(M::AbstractManifold, p, X, q, m::VectorTransportTo)
+function _vector_transport_to(M::AbstractManifold, p, X, q, m::VectorTransportTo; kwargs...)
     d = inverse_retract(M, p, q, m.inverse_retraction)
-    return vector_transport_direction(M, p, X, d, m.vector_transport)
+    v =
+        length(kwargs) > 0 ? VectorTransportWithKeywords(m.vector_transport, kwargs) :
+        m.vector_transport
+    return vector_transport_direction(M, p, X, d, v)
 end
-function _vector_transport_to(M::AbstractManifold, p, X, q, ::ParallelTransport)
-    return parallel_transport_to(M, p, X, q)
+function _vector_transport_to(M::AbstractManifold, p, X, q, ::ParallelTransport; kwargs...)
+    return parallel_transport_to(M, p, X, q; kwargs...)
 end
 function _vector_transport_to(
     M::AbstractManifold,
     p,
     X,
     q,
-    m::DifferentiatedRetractionVectorTransport,
+    m::DifferentiatedRetractionVectorTransport;
+    kwargs...,
 )
-    return vector_transport_to_diff(M, p, X, q, m.retraction)
+    return vector_transport_to_diff(M, p, X, q, m.retraction; kwargs...)
+end
+function _vector_transport_to(
+    M::AbstractManifold,
+    p,
+    X,
+    q,
+    m::VectorTransportWithKeywords;
+    kwargs...,
+)
+    return _vector_transport_to(M, p, X, q, m.vector_transport; kwargs..., m.kwargs...)
 end
 @doc raw"""
     vector_transport_to_diff(M::AbstractManifold, p, X, q, r)
 
 Compute a vector transport by using a [`DifferentiatedRetractionVectorTransport`](@ref) `r`.
 """
-function vector_transport_to_diff(M::AbstractManifold, p, X, q, r)
+function vector_transport_to_diff(M::AbstractManifold, p, X, q, r; kwargs...)
     Y = allocate_result(M, vector_transport_to, X, p)
-    return vector_transport_to_diff!(M, Y, p, X, q, r)
+    return vector_transport_to_diff!(M, Y, p, X, q, r; kwargs...)
 end
 @doc raw"""
     vector_transport_to_diff(M::AbstractManifold, p, X, q, r)
@@ -992,8 +1142,15 @@ vector_transport_to_diff!(M::AbstractManifold, Y, p, X, q, r)
 
 function vector_transport_to_diff! end
 
-function _vector_transport_to(M::AbstractManifold, p, X, q, ::ProjectionTransport)
-    return vector_transport_to_project(M, p, X, q)
+function _vector_transport_to(
+    M::AbstractManifold,
+    p,
+    X,
+    q,
+    ::ProjectionTransport;
+    kwargs...,
+)
+    return vector_transport_to_project(M, p, X, q; kwargs...)
 end
 @doc raw"""
     vector_transport_to_project(M::AbstractManifold, p, X, q)
@@ -1001,9 +1158,9 @@ end
 Compute a vector transport by projecting ``X\in T_p\mathcal M`` onto the tangent
 space ``T_q\mathcal M`` at ``q``.
 """
-function vector_transport_to_project(M::AbstractManifold, p, X, q)
+function vector_transport_to_project(M::AbstractManifold, p, X, q; kwargs...)
     Y = allocate_result(M, vector_transport_to, X, p)
-    return vector_transport_to_project!(M, Y, p, X, q)
+    return vector_transport_to_project!(M, Y, p, X, q; kwargs...)
 end
 @doc raw"""
     vector_transport_to_project!(M::AbstractManifold, Y, p, X, q)
@@ -1011,9 +1168,9 @@ end
 Compute a vector transport by projecting ``X\in T_p\mathcal M`` onto the tangent
 space ``T_q\mathcal M`` at ``q`` in place of `Y`.
 """
-function vector_transport_to_project!(M::AbstractManifold, Y, p, X, q)
+function vector_transport_to_project!(M::AbstractManifold, Y, p, X, q; kwargs...)
     # Note that we have to use embed (not embed!) since we do not have memory to store this embedded value in
-    return project!(M, Y, q, embed(M, p, X))
+    return project!(M, Y, q, embed(M, p, X); kwargs...)
 end
 
 
@@ -1037,12 +1194,17 @@ function vector_transport_to!(
 )
     return _vector_transport_to!(M, Y, p, X, q, m)
 end
-function _vector_transport_to!(M::AbstractManifold, Y, p, X, q, m::VectorTransportTo)
+function _vector_transport_to!(
+    M::AbstractManifold,
+    Y,
+    p,
+    X,
+    q,
+    m::VectorTransportTo;
+    kwargs...,
+)
     d = inverse_retract(M, p, q, m.inverse_retraction)
-    return vector_transport_direction!(M, Y, p, X, d, m.vector_transport)
-end
-function _vector_transport_to!(M::AbstractManifold, Y, p, X, q, ::ParallelTransport)
-    return parallel_transport_to!(M, Y, p, X, q)
+    return vector_transport_direction!(M, Y, p, X, d, m.vector_transport; kwargs...)
 end
 function _vector_transport_to!(
     M::AbstractManifold,
@@ -1050,20 +1212,55 @@ function _vector_transport_to!(
     p,
     X,
     q,
-    m::DifferentiatedRetractionVectorTransport,
+    ::ParallelTransport;
+    kwargs...,
 )
-    return vector_transport_to_diff!(M, Y, p, X, q, m.retraction)
+    return parallel_transport_to!(M, Y, p, X, q; kwargs...)
+end
+function _vector_transport_to!(
+    M::AbstractManifold,
+    Y,
+    p,
+    X,
+    q,
+    m::DifferentiatedRetractionVectorTransport;
+    kwargs...,
+)
+    return vector_transport_to_diff!(M, Y, p, X, q, m.retraction; kwargs...)
 end
 
-function _vector_transport_to!(M::AbstractManifold, Y, p, X, q, ::ProjectionTransport)
-    return vector_transport_to_project!(M, Y, p, X, q)
+function _vector_transport_to!(
+    M::AbstractManifold,
+    Y,
+    p,
+    X,
+    q,
+    ::ProjectionTransport;
+    kwargs...,
+)
+    return vector_transport_to_project!(M, Y, p, X, q; kwargs...)
 end
 
-function _vector_transport_to(M::AbstractManifold, p, X, q, m::PoleLadderTransport)
+function _vector_transport_to(
+    M::AbstractManifold,
+    p,
+    X,
+    q,
+    m::PoleLadderTransport;
+    kwargs...,
+)
     Y = allocate_result(M, vector_transport_to, X, p)
-    return _vector_transport_to!(M, Y, p, X, q, m)
+    return _vector_transport_to!(M, Y, p, X, q, m; kwargs...)
 end
-function _vector_transport_to!(M::AbstractManifold, Y, p, X, q, m::PoleLadderTransport)
+function _vector_transport_to!(
+    M::AbstractManifold,
+    Y,
+    p,
+    X,
+    q,
+    m::PoleLadderTransport;
+    kwargs...,
+)
     inverse_retract!(
         M,
         Y,
@@ -1075,27 +1272,70 @@ function _vector_transport_to!(M::AbstractManifold, Y, p, X, q, m::PoleLadderTra
             q;
             retraction = m.retraction,
             inverse_retraction = m.inverse_retraction,
+            kwargs...,
         ),
         m.inverse_retraction,
     )
     copyto!(Y, -Y)
     return Y
 end
-
-function _vector_transport_to(M::AbstractManifold, p, X, c, m::ScaledVectorTransport)
+function _vector_transport_to(
+    M::AbstractManifold,
+    p,
+    X,
+    c,
+    m::ScaledVectorTransport;
+    kwargs...,
+)
     Y = allocate_result(M, vector_transport_to, X, p)
-    return _vector_transport_to!(M, Y, p, X, c, m)
+    return _vector_transport_to!(M, Y, p, X, c, m; kwargs...)
 end
-function _vector_transport_to!(M::AbstractManifold, Y, p, X, q, m::ScaledVectorTransport)
-    vector_transport_to!(M, Y, p, X, q, m.method)
+function _vector_transport_to!(
+    M::AbstractManifold,
+    Y,
+    p,
+    X,
+    q,
+    m::ScaledVectorTransport;
+    kwargs...,
+)
+    v = length(kwargs) > 0 ? VectorTransportWithKeywords(m.method, kwargs) : m.method
+    vector_transport_to!(M, Y, p, X, q, v)
     Y .*= norm(M, p, X) / norm(M, q, Y)
     return Y
 end
-function _vector_transport_to(M::AbstractManifold, p, X, c, m::SchildsLadderTransport)
-    Y = allocate_result(M, vector_transport_to, X, p)
-    return _vector_transport_to!(M, Y, p, X, c, m)
+function _vector_transport_to!(
+    M::AbstractManifold,
+    Y,
+    p,
+    X,
+    q,
+    m::VectorTransportWithKeywords;
+    kwargs...,
+)
+    return _vector_transport_to!(M, Y, p, X, q, m.vector_transport; kwargs..., m.kwargs...)
 end
-function _vector_transport_to!(M::AbstractManifold, Y, p, X, q, m::SchildsLadderTransport)
+
+function _vector_transport_to(
+    M::AbstractManifold,
+    p,
+    X,
+    c,
+    m::SchildsLadderTransport;
+    kwargs...,
+)
+    Y = allocate_result(M, vector_transport_to, X, p)
+    return _vector_transport_to!(M, Y, p, X, c, m; kwargs...)
+end
+function _vector_transport_to!(
+    M::AbstractManifold,
+    Y,
+    p,
+    X,
+    q,
+    m::SchildsLadderTransport;
+    kwargs...,
+)
     return inverse_retract!(
         M,
         Y,
@@ -1107,6 +1347,7 @@ function _vector_transport_to!(M::AbstractManifold, Y, p, X, q, m::SchildsLadder
             q;
             retraction = m.retraction,
             inverse_retraction = m.inverse_retraction,
+            kwargs...,
         ),
         m.inverse_retraction,
     )

--- a/src/vector_transport.jl
+++ b/src/vector_transport.jl
@@ -293,7 +293,7 @@ last layer would be implemented with keywords, so this way they can be passed do
 * `vector_transport` the vector transport that is decorated with keywords
 * `kwargs` the keyword arguments
 
-Note that you can nest this type. Then the most outer specification of a keyword wins.
+Note that you can nest this type. Then the most outer specification of a keyword is used.
 
 ## Constructor
 

--- a/test/bases.jl
+++ b/test/bases.jl
@@ -52,7 +52,7 @@ allocate(a::NonBroadcastBasisThing) = NonBroadcastBasisThing(allocate(a.v))
 function allocate(a::NonBroadcastBasisThing, ::Type{T}) where {T}
     return NonBroadcastBasisThing(allocate(a.v, T))
 end
-allocate(::NonBroadcastBasisThing, ::Type{T}, s::Integer) where {S,T} = Vector{T}(undef, s)
+allocate(::NonBroadcastBasisThing, ::Type{T}, s::Integer) where {T} = Vector{T}(undef, s)
 
 function copyto!(a::NonBroadcastBasisThing, b::NonBroadcastBasisThing)
     copyto!(a.v, b.v)

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -25,6 +25,8 @@ using Test
 struct CustomDefinedRetraction <: ManifoldsBase.AbstractRetractionMethod end
 struct CustomUndefinedRetraction <: ManifoldsBase.AbstractRetractionMethod end
 struct CustomDefinedKeywordRetraction <: ManifoldsBase.AbstractRetractionMethod end
+struct CustomDefinedKeywordInverseRetraction <:
+       ManifoldsBase.AbstractInverseRetractionMethod end
 struct CustomDefinedInverseRetraction <: ManifoldsBase.AbstractInverseRetractionMethod end
 
 struct DefaultPoint{T} <: AbstractManifoldPoint
@@ -108,6 +110,45 @@ end
 function inverse_retract_custom(::DefaultManifold, p::DefaultPoint, q::DefaultPoint)
     return DefaultTVector(q.value - 2 * p.value)
 end
+function ManifoldsBase._inverse_retract(
+    M::DefaultManifold,
+    p,
+    q,
+    ::CustomDefinedKeywordInverseRetraction;
+    kwargs...,
+)
+    return inverse_retract_custom_kw(M, p, q; kwargs...)
+end
+function inverse_retract_custom_kw(
+    ::DefaultManifold,
+    p::DefaultPoint,
+    q::DefaultPoint;
+    scale = 2.0,
+)
+    return DefaultTVector(q.value - scale * p.value)
+end
+function ManifoldsBase._inverse_retract!(
+    M::DefaultManifold,
+    X,
+    p,
+    q,
+    ::CustomDefinedKeywordInverseRetraction;
+    kwargs...,
+)
+    return inverse_retract_custom_kw!(M, X, p, q; kwargs...)
+end
+function inverse_retract_custom_kw!(
+    ::DefaultManifold,
+    X::DefaultTVector,
+    p::DefaultPoint,
+    q::DefaultPoint;
+    scale = 2.0,
+)
+    X.value .= q.value - scale * p.value
+    return X
+end
+
+
 struct MatrixVectorTransport{T} <: AbstractVector{T}
     m::Matrix{T}
 end
@@ -594,6 +635,14 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
         pRK = allocate(p, eltype(p.value), size(p.value))
         @test retract(M, p, X, mRK) == DefaultPoint(3 * p.value + X.value)
         @test retract!(M, pRK, p, X, mRK) == DefaultPoint(3 * p.value + X.value)
+        mIRK = InverseRetractionWithKeywords(
+            CustomDefinedKeywordInverseRetraction();
+            scale = 3.0,
+        )
+        XIRK = allocate(X, eltype(X.value), size(X.value))
+        @test inverse_retract(M, p, pRK, mIRK) == DefaultTVector(pRK.value - 3 * p.value)
+        @test inverse_retract!(M, XIRK, p, pRK, mIRK) ==
+              DefaultTVector(pRK.value - 3 * p.value)
         p2 = allocate(p, eltype(p.value), size(p.value))
         @test size(p2.value) == size(p.value)
         X2 = allocate(X, eltype(X.value), size(X.value))

--- a/test/validation_manifold.jl
+++ b/test/validation_manifold.jl
@@ -161,22 +161,22 @@ end
                 @test_throws ErrorException get_basis(A, x, CachedBasis(cb, [x]))
                 @test_throws ErrorException get_basis(A, x, CachedBasis(cb, [x, x, x]))
                 @test_throws ErrorException get_basis(A, x, CachedBasis(cb, [2 * x, x, x]))
-                if BT <: ManifoldsBase.AbstractOrthogonalBasis
-                    @test_throws ArgumentError get_basis(
-                        A,
-                        x,
-                        CachedBasis(
-                            cb,
-                            [[1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
-                        ),
-                    )
-                elseif BT <: ManifoldsBase.AbstractOrthonormalBasis
+                if BT <: ManifoldsBase.AbstractOrthonormalBasis
                     @test_throws ArgumentError get_basis(
                         A,
                         x,
                         CachedBasis(
                             cb,
                             [[2.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
+                        ),
+                    )
+                elseif BT <: ManifoldsBase.AbstractOrthogonalBasis
+                    @test_throws ArgumentError get_basis(
+                        A,
+                        x,
+                        CachedBasis(
+                            cb,
+                            [[1.0, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, 1.0]],
                         ),
                     )
                 end

--- a/test/vector_transport.jl
+++ b/test/vector_transport.jl
@@ -8,8 +8,8 @@ import ManifoldsBase: parallel_transport_to!, parallel_transport_along!
 struct NonDefaultEuclidean <: AbstractManifold{ManifoldsBase.ℝ} end
 ManifoldsBase.log!(::NonDefaultEuclidean, v, x, y) = (v .= y .- x)
 ManifoldsBase.exp!(::NonDefaultEuclidean, y, x, v) = (y .= x .+ v)
-function ManifoldsBase.parallel_transport_to!(::NonDefaultEuclidean, Y, p, X, q)
-    return copyto!(Y, X)
+function ManifoldsBase.parallel_transport_to!(::NonDefaultEuclidean, Y, p, X, q; a = 0)
+    return copyto!(Y, X .+ a)
 end
 function ManifoldsBase.parallel_transport_along!(
     ::NonDefaultEuclidean,
@@ -35,6 +35,9 @@ end
             @test vector_transport_along(M, pts[1], X2, [], SchildsLadderTransport()) == X2
             @test vector_transport_along(M, pts[1], X2, [], PoleLadderTransport()) == X2
             @test vector_transport_along(M, pts[1], X2, [], ParallelTransport()) == X2
+            kwP = VectorTransportWithKeywords(ParallelTransport())
+            @test vector_transport_along(M, pts[1], X2, [], kwP) == X2
+            @test vector_transport_along!(M, X2, pts[1], X2, [], kwP) == X2
             # check mutating ones with defaults
             p = allocate(pts[1])
             ManifoldsBase.pole_ladder!(M, p, pts[1], pts[2], pts[3])
@@ -58,4 +61,10 @@ end
     VT2 = VectorTransportTo()
     @test vector_transport_to(M, p, X, q, VT2) == X
     @test vector_transport_to!(M, Y, p, X, q, VT2) == X
+    VT3 = VectorTransportWithKeywords(VT; a = 1)
+    @test vector_transport_direction(M, p, X, q, VT3) == (X .+ 1)
+    @test vector_transport_direction!(M, Y, p, X, q, VT3) == (X .+ 1)
+    VT4 = VectorTransportWithKeywords(VT2; a = 2)
+    @test vector_transport_to(M, p, X, q, VT4) == (X .+ 2)
+    @test vector_transport_to!(M, Y, p, X, q, VT4) == (X .+ 2)
 end


### PR DESCRIPTION
This is a continuation of https://github.com/JuliaManifolds/Manifolds.jl/issues/547, to introduce retractions (and inverse retractions and vector transports) where you can fix keywords in the retraction types.

This is necessary since keywords only act on layer 3 on the actual implementation – and with this step they are “added” in layer two before “resolving” the retraction type and passing them down to layer 3.