### PR TITLE
Introduce more error modes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.24"
+version = "0.13.25"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/DefaultManifold.jl
+++ b/src/DefaultManifold.jl
@@ -14,6 +14,24 @@ function DefaultManifold(n::Vararg{Int,N}; field = ℝ) where {N}
     return DefaultManifold{Tuple{n...},field}()
 end
 
+
+
+function check_approx(M::DefaultManifold, p, q; kwargs...)
+    res = isapprox(p, q; kwargs...)
+    res && return nothing
+    v = distance(M, p, q)
+    s = "The two points $p and $q on $M are not (approximately) equal."
+    return ApproximatelyError(v, s)
+end
+
+function check_approx(M::DefaultManifold, p, X, Y; kwargs...)
+    res = isapprox(X, Y; kwargs...)
+    res && return nothing
+    v = norm(M, p, X - Y)
+    s = "The two tangent vectors $X and $Y in the tangent space at $p on $M are not (approximately) equal."
+    return ApproximatelyError(v, s)
+end
+
 distance(::DefaultManifold, p, q) = norm(p - q)
 
 embed!(::DefaultManifold, q, p) = copyto!(q, p)

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -169,7 +169,7 @@ function check_approx(M::AbstractManifold, p, q; kwargs...)
     s = "The two points $p and $q on $M are not (approximately) equal."
     return ApproximatelyError(s)
 end
-function check_approx(M, p, X, Y; kwargs...)
+function check_approx(M::AbstractManifold, p, X, Y; kwargs...)
     # fall back to classical mode - just that we do not have a reason then
     res = isapprox(X, Y; kwargs...)
     res && return nothing

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -441,8 +441,17 @@ inner(M::AbstractManifold, p, X, Y)
 
 """
     isapprox(M::AbstractManifold, p, q; kwargs...)
+    isapprox(M::AbstractManifold, p, q, error::Symbol; kwargs...)
 
 Check if points `p` and `q` from [`AbstractManifold`](@ref) `M` are approximately equal.
+
+The optional positional argument can be used to get more information for the case that
+the result is false, if the concrete manifold provides such information.
+Currently the following are supported
+* `:error` - throws an error if `isapprox` evaluates to false, providing possibly a more detailed error.
+  Note that this turns `isapprox` basically to an `@assert`.
+* `:info` – prints the information in an `@info`
+* `:warning` – prints the information in an `@warn`
 
 Keyword arguments can be used to specify tolerances.
 """
@@ -450,13 +459,29 @@ isapprox(::AbstractManifold, x, y; kwargs...) = isapprox(x, y; kwargs...)
 
 """
     isapprox(M::AbstractManifold, p, X, Y; kwargs...)
+    isapprox(M::AbstractManifold, p, X, Y, error:Symbol; kwargs...)
 
 Check if vectors `X` and `Y` tangent at `p` from [`AbstractManifold`](@ref) `M` are approximately
 equal.
 
+The optional positional argument can be used to get more information for the case that
+the result is false, if the concrete manifold provides such information.
+Currently the following are supported
+
+* `:error` - throws an error if `isapprox` evaluates to false, providing possibly a more detailed error.
+  Note that this turns `isapprox` basically to an `@assert`.
+* `:info` – prints the information in an `@info`
+* `:warning` – prints the information in an `@warn`
+
+By default these informations are collected by calling [`check_approx`](@ref).
+
 Keyword arguments can be used to specify tolerances.
 """
 isapprox(::AbstractManifold, p, X, Y; kwargs...) = isapprox(X, Y; kwargs...)
+
+function isapprox(M::AbstractManifold, p, X, Y, error::Symbol; kwargs...)
+
+end
 
 
 """

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -450,7 +450,7 @@ Currently the following are supported
 * `:error` - throws an error if `isapprox` evaluates to false, providing possibly a more detailed error.
   Note that this turns `isapprox` basically to an `@assert`.
 * `:info` – prints the information in an `@info`
-* `:warning` – prints the information in an `@warn`
+* `:warn` – prints the information in an `@warn`
 * `:none` (default) – the function just returns `true`/`false`
 
 Keyword arguments can be used to specify tolerances.
@@ -465,7 +465,7 @@ function isapprox(M::AbstractManifold, p, q; error::Symbol = :none, kwargs...)
             s = "$(typeof(ma)) with $(ma.val)\n$(ma.msg)"
         end
         (error === :info) && @info s
-        (error === :warning) && @warn s
+        (error === :warn) && @warn s
         return false
     end
     return true
@@ -494,7 +494,7 @@ Currently the following are supported
 * `:error` - throws an error if `isapprox` evaluates to false, providing possibly a more detailed error.
   Note that this turns `isapprox` basically to an `@assert`.
 * `:info` – prints the information in an `@info`
-* `:warning` – prints the information in an `@warn`
+* `:warn` – prints the information in an `@warn`
 * `:none` (default) – the function just returns `true`/`false`
 
 By default these informations are collected by calling [`check_approx`](@ref).
@@ -511,7 +511,7 @@ function isapprox(M::AbstractManifold, p, X, Y; error::Symbol = :none, kwargs...
             s = "$(typeof(mat)) with $(mat.val)\n$(mat.msg)"
         end
         (error === :info) && @info s
-        (error === :warning) && @warn s
+        (error === :warn) && @warn s
         return false
     end
     return true
@@ -540,7 +540,7 @@ is `nothing` or an error.
 A more precise way can be set using a symbol as the optional parameter, where
 ' `:error` is the same as setting `throw_error=true`
 ' `:info` displays the error message as an `@info`
-* `:warning` displays the error message as a `@warning`
+* `:warn` displays the error message as a `@warning`
 
 all other symbols are equivalent to `throw_error=false`.
 """
@@ -561,14 +561,14 @@ function is_point(M::AbstractManifold, p, error::Symbol; kwargs...)
     if mps !== nothing
         s = "$(typeof(mps)) with $(mps.val)\n$(mps.msg)"
         (error === :info) && @info s
-        (error === :warning) && @warn s
+        (error === :warn) && @warn s
         return false
     end
     mpe = check_point(M, p; kwargs...)
     if mpe !== nothing
         s = "$(typeof(mpe)) with $(mpe.val)\n$(mpe.msg)"
         (error === :info) && @info s
-        (error === :warning) && @warn s
+        (error === :warn) && @warn s
         return false
     end
     return true
@@ -593,7 +593,7 @@ If `check_base_point` is true, then the point `p` will be first checked using th
 A more precise way can be set using a symbol as the optional parameter, where
 ' `:error` is the same as setting `throw_error=true`
 ' `:info` displays the error message as an `@info`
-* `:warning` displays the error message as a `@warn`ing.
+* `:warn` displays the error message as a `@warn`ing.
 
 all other symbols are equivalent to `throw_error=false`.
 """
@@ -637,14 +637,14 @@ function is_vector(
     if mXs !== nothing
         s = "$(typeof(mXs)) with $(mXs.val)\n$(mXs.msg)"
         (error === :info) && @info s
-        (error === :warning) && @warn s
+        (error === :warn) && @warn s
         return false
     end
     mXe = check_vector(M, p, X; kwargs...)
     if mXe !== nothing
         s = "$(typeof(mXe)) with $(mXe.val)\n$(mXe.msg)"
         (error === :info) && @info s
-        (error === :warning) && @warn s
+        (error === :warn) && @warn s
         return false
     end
     return true

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -455,7 +455,28 @@ Currently the following are supported
 
 Keyword arguments can be used to specify tolerances.
 """
-isapprox(::AbstractManifold, x, y; kwargs...) = isapprox(x, y; kwargs...)
+isapprox(::AbstractManifold, p, q; kwargs...) = isapprox(p, q; kwargs...)
+
+
+function isapprox(M::AbstractManifold, p, q, error::Symbol; kwargs...)
+    ma = check_approx(M, p, q; kwargs...)
+    if ma !== nothing
+        (error === :error) && throw(ma)
+        s = "$(typeof(ma)) with\n$(ma.msg)"
+        (error === :info) && @info s
+        (error === :warning) && @warn s
+        return false
+    end
+end
+
+function check_approx(M, p, q; kwargs...)
+    # fall back to old mode - just that we do not have a reason then
+    res = isapprox(M, p, q; kwargs...)
+    res && return nothing
+    s = "The two points $p and $q on $M are not (approximately) equal."
+    return AssertionError(s)
+end
+
 
 """
     isapprox(M::AbstractManifold, p, X, Y; kwargs...)
@@ -480,7 +501,22 @@ Keyword arguments can be used to specify tolerances.
 isapprox(::AbstractManifold, p, X, Y; kwargs...) = isapprox(X, Y; kwargs...)
 
 function isapprox(M::AbstractManifold, p, X, Y, error::Symbol; kwargs...)
+    mat = check_approx(M, p, X, Y; kwargs...)
+    if mat !== nothing
+        (error === :error) && throw(mat)
+        s = "$(typeof(mat)) with\n$(mat.msg)"
+        (error === :info) && @info s
+        (error === :warning) && @warn s
+        return false
+    end
+end
 
+function check_approx(M, p, X, Y; kwargs...)
+    # fall back to old mode - just that we do not have a reason then
+    res = isapprox(M, p, X, Y; kwargs...)
+    res && return nothing
+    s = "The two tangent vectors $X and $Y in the tangent space at $p on $M are not (approximately) equal."
+    return AssertionError(s)
 end
 
 

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -521,9 +521,8 @@ function check_approx(M, p, X, Y; kwargs...)
     # fall back to classical mode - just that we do not have a reason then
     res = isapprox(X, Y; kwargs...)
     res && return nothing
-    v = norm(M, p, X - Y)
     s = "The two tangent vectors $X and $Y in the tangent space at $p on $M are not (approximately) equal."
-    return ApproximatelyError(v, s)
+    return ApproximatelyError(s)
 end
 
 

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -521,7 +521,7 @@ function check_approx(M, p, X, Y; kwargs...)
     # fall back to classical mode - just that we do not have a reason then
     res = isapprox(X, Y; kwargs...)
     res && return nothing
-    v = norm(X - Y)
+    v = norm(M, p, X - Y)
     s = "The two tangent vectors $X and $Y in the tangent space at $p on $M are not (approximately) equal."
     return ApproximatelyError(v, s)
 end
@@ -578,7 +578,7 @@ end
 
 """
     is_vector(M::AbstractManifold, p, X, throw_error = false, check_base_point=true; kwargs...)
-    is_vector(M::AbstractManifold, p, X, error::Symbol, check_base_point=true; kwargs...)
+    is_vector(M::AbstractManifold, p, X, error::Symbol, check_base_point::Bool=true; kwargs...)
 
 Return whether `X` is a valid tangent vector at point `p` on the [`AbstractManifold`](@ref) `M`.
 Returns either `true` or `false`.

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -467,14 +467,15 @@ function isapprox(M::AbstractManifold, p, q; error::Symbol = :none, kwargs...)
         (error === :warning) && @warn s
         return false
     end
+    return true
 end
 
-function check_approx(M, p, q; kwargs...)
-    # fall back to old mode - just that we do not have a reason then
-    res = isapprox(M, p, q; kwargs...)
+function check_approx(M::AbstractManifold, p, q; kwargs...)
+    # fall back to classical approx mode - just that we do not have a reason then
+    res = isapprox(p, q; kwargs...)
     res && return nothing
     s = "The two points $p and $q on $M are not (approximately) equal."
-    return AssertionError(s)
+    return ApproximatelyError(s)
 end
 
 
@@ -513,11 +514,12 @@ function isapprox(M::AbstractManifold, p, X, Y; error::Symbol = :none, kwargs...
         (error === :warning) && @warn s
         return false
     end
+    return true
 end
 
 function check_approx(M, p, X, Y; kwargs...)
-    # fall back to old mode - just that we do not have a reason then
-    res = isapprox(M, p, X, Y; kwargs...)
+    # fall back to classical mode - just that we do not have a reason then
+    res = isapprox(X, Y; kwargs...)
     res && return nothing
     s = "The two tangent vectors $X and $Y in the tangent space at $p on $M are not (approximately) equal."
     return ApproximatelyError(s)

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -522,7 +522,12 @@ function check_approx(M, p, X, Y; kwargs...)
     res = isapprox(X, Y; kwargs...)
     res && return nothing
     s = "The two tangent vectors $X and $Y in the tangent space at $p on $M are not (approximately) equal."
-    return ApproximatelyError(s)
+    v = try
+        norm(M, p, X - Y)
+    catch e
+        NaN
+    end
+    return ApproximatelyError(v, s)
 end
 
 

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -451,6 +451,7 @@ Currently the following are supported
   Note that this turns `isapprox` basically to an `@assert`.
 * `:info` – prints the information in an `@info`
 * `:warning` – prints the information in an `@warn`
+* `:none` (default) – the function just returns `true`/`false`
 
 Keyword arguments can be used to specify tolerances.
 """
@@ -473,6 +474,7 @@ end
 function check_approx(M::AbstractManifold, p, q; kwargs...)
     # fall back to classical approx mode - just that we do not have a reason then
     res = isapprox(p, q; kwargs...)
+    # since we can not assume distance to be implemented, we can not provide a default value
     res && return nothing
     s = "The two points $p and $q on $M are not (approximately) equal."
     return ApproximatelyError(s)
@@ -480,8 +482,7 @@ end
 
 
 """
-    isapprox(M::AbstractManifold, p, X, Y; kwargs...)
-    isapprox(M::AbstractManifold, p, X, Y, error:Symbol; kwargs...)
+    isapprox(M::AbstractManifold, p, X, Y; error:Symbol=:none; kwargs...)
 
 Check if vectors `X` and `Y` tangent at `p` from [`AbstractManifold`](@ref) `M` are approximately
 equal.
@@ -494,13 +495,12 @@ Currently the following are supported
   Note that this turns `isapprox` basically to an `@assert`.
 * `:info` – prints the information in an `@info`
 * `:warning` – prints the information in an `@warn`
+* `:none` (default) – the function just returns `true`/`false`
 
 By default these informations are collected by calling [`check_approx`](@ref).
 
 Keyword arguments can be used to specify tolerances.
 """
-isapprox(::AbstractManifold, p, X, Y; kwargs...) = isapprox(X, Y; kwargs...)
-
 function isapprox(M::AbstractManifold, p, X, Y; error::Symbol = :none, kwargs...)
     mat = check_approx(M, p, X, Y; kwargs...)
     if mat !== nothing
@@ -521,8 +521,9 @@ function check_approx(M, p, X, Y; kwargs...)
     # fall back to classical mode - just that we do not have a reason then
     res = isapprox(X, Y; kwargs...)
     res && return nothing
+    v = norm(X - Y)
     s = "The two tangent vectors $X and $Y in the tangent space at $p on $M are not (approximately) equal."
-    return ApproximatelyError(s)
+    return ApproximatelyError(v, s)
 end
 
 

--- a/src/ValidationManifold.jl
+++ b/src/ValidationManifold.jl
@@ -270,8 +270,14 @@ end
 function is_point(M::ValidationManifold, p, te = false; kw...)
     return is_point(M.manifold, array_value(p), te; kw...)
 end
+function is_point(M::ValidationManifold, p, e::Symbol; kw...)
+    return is_point(M.manifold, array_value(p), e; kw...)
+end
 function is_vector(M::ValidationManifold, p, X, te = false, cbp = true; kw...)
     return is_vector(M.manifold, array_value(p), array_value(X), te, cbp; kw...)
+end
+function is_vector(M::ValidationManifold, p, X, e::Symbol, cbp = true; kw...)
+    return is_vector(M.manifold, array_value(p), array_value(X), e, cbp; kw...)
 end
 
 function isapprox(M::ValidationManifold, p, q; kwargs...)

--- a/src/ValidationManifold.jl
+++ b/src/ValidationManifold.jl
@@ -267,13 +267,13 @@ function inner(M::ValidationManifold, p, X, Y; kwargs...)
 end
 
 
-function is_point(M::ValidationManifold, p, te = false; kw...)
+function is_point(M::ValidationManifold, p, te::Bool = false; kw...)
     return is_point(M.manifold, array_value(p), te; kw...)
 end
 function is_point(M::ValidationManifold, p, e::Symbol; kw...)
     return is_point(M.manifold, array_value(p), e; kw...)
 end
-function is_vector(M::ValidationManifold, p, X, te = false, cbp = true; kw...)
+function is_vector(M::ValidationManifold, p, X, te::Bool = false, cbp = true; kw...)
     return is_vector(M.manifold, array_value(p), array_value(X), te, cbp; kw...)
 end
 function is_vector(M::ValidationManifold, p, X, e::Symbol, cbp = true; kw...)

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -330,14 +330,14 @@ end
 @trait_function isapprox(M::AbstractDecoratorManifold, p, X, Y; kwargs...)
 
 # Introduce Deco Trait | automatic foward | fallback
-@trait_function is_point(M::AbstractDecoratorManifold, p, te = false; kwargs...)
+@trait_function is_point(M::AbstractDecoratorManifold, p, te::Bool = false; kwargs...)
 @trait_function is_point(M::AbstractDecoratorManifold, p, e::Symbol; kwargs...)
 # Embedded
 function is_point(
     ::TraitList{IsEmbeddedManifold},
     M::AbstractDecoratorManifold,
     p,
-    te = false;
+    te::Bool = false;
     kwargs...,
 )
     # to be safe check_size first
@@ -369,7 +369,7 @@ end
     M::AbstractDecoratorManifold,
     p,
     X,
-    te = false,
+    te::Bool = false,
     cbp = true;
     kwargs...,
 )
@@ -388,7 +388,7 @@ function is_vector(
     M::AbstractDecoratorManifold,
     p,
     X,
-    te = false,
+    te::Bool = false,
     cbp = true;
     kwargs...,
 )

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -331,6 +331,7 @@ end
 
 # Introduce Deco Trait | automatic foward | fallback
 @trait_function is_point(M::AbstractDecoratorManifold, p, te = false; kwargs...)
+@trait_function is_point(M::AbstractDecoratorManifold, p, e::Symbol; kwargs...)
 # Embedded
 function is_point(
     ::TraitList{IsEmbeddedManifold},
@@ -369,6 +370,14 @@ end
     p,
     X,
     te = false,
+    cbp = true;
+    kwargs...,
+)
+@trait_function is_vector(
+    M::AbstractDecoratorManifold,
+    p,
+    X,
+    e::Symbol,
     cbp = true;
     kwargs...,
 )

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -31,7 +31,6 @@ struct ApproximatelyError{V,S} <: Exception
     val::V
     msg::S
 end
-ApproximatelyError(val::V, msg::S) where {V,S} = ApproximatelyError{V,S}(val, msg)
 ApproximatelyError(msg::S) where {S} = ApproximatelyError{Float64,S}(NaN, msg)
 
 function Base.show(io::IO, ex::ApproximatelyError)

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -22,9 +22,9 @@ Store an error that occurs when two data structures, e.g. points or tangent vect
 
 Generate an Error with value `val` and message `msg`.
 
-ApproximatelyError(msg::S) where {S}
+    ApproximatelyError(msg::S) where {S}
 
-Generate a message without a value (using `NaN` internally) and message `msg`.
+Generate a message without a value (using `val=NaN` internally) and message `msg`.
 
 """
 struct ApproximatelyError{V,S} <: Exception

--- a/src/errors.jl
+++ b/src/errors.jl
@@ -5,6 +5,44 @@ An absytract Case for Errors when checking validity of points/vectors on mainfol
 """
 abstract type AbstractManifoldDomainError <: Exception end
 
+
+@doc """
+    ApproximatelyError{V,S} <: Exception
+
+Store an error that occurs when two data structures, e.g. points or tangent vectors.
+
+# Fields
+
+* `val` amount the two approximate elements are apart – is set to `NaN` if this is not known
+* `msg` a message providing more detail about the performed test and why it failed.
+
+# Constructors
+
+    ApproximatelyError(val::V, msg::S) where {V,S}
+
+Generate an Error with value `val` and message `msg`.
+
+ApproximatelyError(msg::S) where {S}
+
+Generate a message without a value (using `NaN` internally) and message `msg`.
+
+"""
+struct ApproximatelyError{V,S} <: Exception
+    val::V
+    msg::S
+end
+ApproximatelyError(val::V, msg::S) where {V,S} = ApproximatelyError{V,S}(val, msg)
+ApproximatelyError(msg::S) where {S} = ApproximatelyError{Float64,S}(NaN, msg)
+
+function Base.show(io::IO, ex::ApproximatelyError)
+    isnan(ex.val) && return print(io, "ApproximatelyError(\"$(ex.msg)\")")
+    return print(io, "ApproximatelyError($(ex.val), \"$(ex.msg)\")")
+end
+function Base.showerror(io::IO, ex::ApproximatelyError)
+    isnan(ex.val) && return print(io, "ApproximatelyError\n$(ex.msg)\n")
+    return print(io, "ApproximatelyError with $(ex.val)\n$(ex.msg)\n")
+end
+
 @doc """
     CompnentError{I,E} <: Exception
 
@@ -12,8 +50,8 @@ Store an error that occured in a component, where the additional `index` is stor
 
 # Fields
 
-* `index` index where the error occured`
-* `error` error that occured.
+* `index::I` index where the error occured`
+* `error::E` error that occured.
 """
 struct ComponentManifoldError{I,E} <: AbstractManifoldDomainError where {I,E<:Exception}
     index::I

--- a/src/point_vector_fallbacks.jl
+++ b/src/point_vector_fallbacks.jl
@@ -124,6 +124,13 @@ macro default_manifold_fallbacks(TM, TP, TV, pfield::Symbol, vfield::Symbol)
             return ManifoldsBase.check_vector(M, p.$pfield, X.$vfield; kwargs...)
         end
 
+        function ManifoldsBase.check_approx(M::$TM, p::$TP, q::$TP; kwargs...)
+            return ManifoldsBase.check_approx(M, p.$pfield, q.$pfield; kwargs...)
+        end
+        function ManifoldsBase.check_approx(M::$TM, p::$TP, X::$TV, Y::$TV; kwargs...)
+            return ManifoldsBase.check_approx(M, p.$pfield, X.$vfield, Y.$vfield; kwargs...)
+        end
+
         function ManifoldsBase.distance(M::$TM, p::$TP, q::$TP)
             return distance(M, p.$pfield, q.$pfield)
         end

--- a/test/bases.jl
+++ b/test/bases.jl
@@ -163,7 +163,10 @@ DiagonalizingBasisProxy() = DiagonalizingOrthonormalBasis([1.0, 0.0, 0.0])
         for pB in
             (ProjectedOrthonormalBasis(:svd), ProjectedOrthonormalBasis(:gram_schmidt))
             if pB isa ProjectedOrthonormalBasis{:gram_schmidt,ℝ}
-                pb = get_basis(
+                pb = @test_logs (
+                    :warn,
+                    "Input vector 4 lies in the span of the previous ones.",
+                ) get_basis(
                     M,
                     x,
                     pB;
@@ -204,8 +207,15 @@ DiagonalizingBasisProxy() = DiagonalizingOrthonormalBasis([1.0, 0.0, 0.0])
             tm = ProjectionTestManifold()
             bt = ProjectedOrthonormalBasis(:gram_schmidt)
             p = [sqrt(2) / 2, 0.0, sqrt(2) / 2, 0.0, 0.0]
-            @test_throws ErrorException get_basis(tm, p, bt)
-            b = get_basis(
+            @test_logs (:warn, "Input only has 5 vectors, but manifold dimension is 100.") (@test_throws ErrorException get_basis(
+                tm,
+                p,
+                bt,
+            ))
+            b = @test_logs (
+                :warn,
+                "Input only has 5 vectors, but manifold dimension is 100.",
+            ) get_basis(
                 tm,
                 p,
                 bt;
@@ -213,7 +223,11 @@ DiagonalizingBasisProxy() = DiagonalizingOrthonormalBasis([1.0, 0.0, 0.0])
                 skip_linearly_dependent = true, #skips 3 and 5
             )
             @test length(get_vectors(tm, p, b)) == 3
-            @test_throws ErrorException ManifoldsBase.gram_schmidt(M, p, [V[1]])
+            @test_logs (:warn, "Input only has 1 vectors, but manifold dimension is 3.") (@test_throws ErrorException ManifoldsBase.gram_schmidt(
+                M,
+                p,
+                [V[1]],
+            ))
             @test_throws ErrorException ManifoldsBase.gram_schmidt(
                 M,
                 p,

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -255,10 +255,13 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
             @test is_vector(M, pts[1], tv1; atol = eps(eltype(pts[1])))
 
             tv2 = log(M, pts[2], pts[1])
+            tv3 = log(M, pts[2], pts[3])
             @test isapprox(M, pts[2], exp(M, pts[1], tv1))
             @test isapprox(M, pts[1], exp(M, pts[1], tv1, 0))
             @test isapprox(M, pts[2], exp(M, pts[1], tv1, 1))
             @test isapprox(M, pts[1], exp(M, pts[2], tv2))
+            @test_throws ApproximatelyError isapprox(M, pts[1], pts[2]; error = :error)
+            @test_throws ApproximatelyError isapprox(M, pts[2], tv2, tv3; error = :error)
             @test is_point(M, retract(M, pts[1], tv1))
             @test isapprox(M, pts[1], retract(M, pts[1], tv1, 0))
 

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -262,6 +262,9 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
             @test isapprox(M, pts[1], exp(M, pts[2], tv2))
             @test_throws ApproximatelyError isapprox(M, pts[1], pts[2]; error = :error)
             @test_throws ApproximatelyError isapprox(M, pts[2], tv2, tv3; error = :error)
+            # test lower level fallbacks
+            @test ManifoldsBase.check_approx(M, pts[1], pts[2]) isa ApproximatelyError
+            @test ManifoldsBase.check_approx(M, pts[2], tv2, tv3) isa ApproximatelyError
             @test is_point(M, retract(M, pts[1], tv1))
             @test isapprox(M, pts[1], retract(M, pts[1], tv1, 0))
 

--- a/test/domain_errors.jl
+++ b/test/domain_errors.jl
@@ -5,11 +5,11 @@ using Test
 struct ErrorTestManifold <: AbstractManifold{ℝ} end
 
 function ManifoldsBase.check_size(::ErrorTestManifold, p)
-    size(p) != (2,) && return DomainError(size(p), " size $p not (2,)")
+    size(p) != (2,) && return DomainError(size(p), "size $p not (2,)")
     return nothing
 end
 function ManifoldsBase.check_size(::ErrorTestManifold, p, X)
-    size(X) != (2,) && return DomainError(size(X), " size $X not (2,)")
+    size(X) != (2,) && return DomainError(size(X), "size $X not (2,)")
     return nothing
 end
 function ManifoldsBase.check_point(::ErrorTestManifold, x)
@@ -36,16 +36,32 @@ end
     @test !is_point(M, [-1, 1])
     @test !is_point(M, [1, 1, 1]) # checksize fails
     @test_throws DomainError is_point(M, [-1, 1, 1], true) # checksize errors
+    @test_throws DomainError is_point(M, [-1, 1, 1], :error) # checksize errors
+    cs = "DomainError with (3,)\nsize [-1, 1, 1] not (2,)"
+    @test_logs (:info, cs) is_point(M, [-1,1,1], :info)
+    @test_logs (:warn, cs) is_point(M, [-1,1,1], :warn)
     @test is_point(M, [1, 1])
     @test_throws DomainError is_point(M, [-1, 1], true)
+    @test_throws DomainError is_point(M, [-1, 1], :error)
+    ps = "DomainError with [-1, 1]\n<0"
+    @test_logs (:info, ps)  is_point(M, [-1, 1], :info)
+    @test_logs (:warn, ps)  is_point(M, [-1, 1], :warn)
 
     @test isa(ManifoldsBase.check_vector(M, [1, 1], [-1, 1]), DomainError)
     @test ManifoldsBase.check_vector(M, [1, 1], [1, 1]) === nothing
     @test !is_vector(M, [1, 1], [-1, 1])
     @test !is_vector(M, [1, 1], [1, 1, 1])
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1, 1], true)
+    @test_throws DomainError is_vector(M, [1, 1], [-1, 1, 1], :error)
+    vs = "DomainError with (3,)\nsize [-1, 1, 1] not (2,)"
+    @test_logs (:info, vs)  is_vector(M, [1, 1], [-1, 1, 1], :info)
+    @test_logs (:warn, vs)  is_vector(M, [1, 1], [-1, 1, 1], :warn)
     @test !is_vector(M, [1, 1, 1], [1, 1, 1], false, true)
     @test_throws DomainError is_vector(M, [1, 1, 1], [1, 1], true, true)
+    @test_throws DomainError is_vector(M, [1, 1, 1], [1, 1], :error, true)
+    ps2 = "DomainError with (3,)\nsize [1, 1, 1] not (2,)"
+    @test_logs (:info, ps2)  is_vector(M, [1, 1, 1], [1, 1], :info, true)
+    @test_logs (:warn, ps2)  is_vector(M, [1, 1, 1], [1, 1], :warn, true)
     @test is_vector(M, [1, 1], [1, 1])
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1], true)
 end

--- a/test/domain_errors.jl
+++ b/test/domain_errors.jl
@@ -41,6 +41,7 @@ end
     @test_logs (:info, cs) is_point(M, [-1, 1, 1], :info)
     @test_logs (:warn, cs) is_point(M, [-1, 1, 1], :warn)
     @test is_point(M, [1, 1])
+    @test is_point(M, [1, 1], :error)
     @test_throws DomainError is_point(M, [-1, 1], true)
     @test_throws DomainError is_point(M, [-1, 1], :error)
     ps = "DomainError with [-1, 1]\n<0"
@@ -63,6 +64,7 @@ end
     @test_logs (:info, ps2) is_vector(M, [1, 1, 1], [1, 1], :info, true)
     @test_logs (:warn, ps2) is_vector(M, [1, 1, 1], [1, 1], :warn, true)
     @test is_vector(M, [1, 1], [1, 1])
+    @test is_vector(M, [1, 1], [1, 1], :none) #default just true/false
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1], true)
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1], :error, true)
     ps3 = "DomainError with [-1, 1]\n<0"

--- a/test/domain_errors.jl
+++ b/test/domain_errors.jl
@@ -38,14 +38,14 @@ end
     @test_throws DomainError is_point(M, [-1, 1, 1], true) # checksize errors
     @test_throws DomainError is_point(M, [-1, 1, 1], :error) # checksize errors
     cs = "DomainError with (3,)\nsize [-1, 1, 1] not (2,)"
-    @test_logs (:info, cs) is_point(M, [-1,1,1], :info)
-    @test_logs (:warn, cs) is_point(M, [-1,1,1], :warn)
+    @test_logs (:info, cs) is_point(M, [-1, 1, 1], :info)
+    @test_logs (:warn, cs) is_point(M, [-1, 1, 1], :warn)
     @test is_point(M, [1, 1])
     @test_throws DomainError is_point(M, [-1, 1], true)
     @test_throws DomainError is_point(M, [-1, 1], :error)
     ps = "DomainError with [-1, 1]\n<0"
-    @test_logs (:info, ps)  is_point(M, [-1, 1], :info)
-    @test_logs (:warn, ps)  is_point(M, [-1, 1], :warn)
+    @test_logs (:info, ps) is_point(M, [-1, 1], :info)
+    @test_logs (:warn, ps) is_point(M, [-1, 1], :warn)
 
     @test isa(ManifoldsBase.check_vector(M, [1, 1], [-1, 1]), DomainError)
     @test ManifoldsBase.check_vector(M, [1, 1], [1, 1]) === nothing
@@ -54,14 +54,14 @@ end
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1, 1], true)
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1, 1], :error)
     vs = "DomainError with (3,)\nsize [-1, 1, 1] not (2,)"
-    @test_logs (:info, vs)  is_vector(M, [1, 1], [-1, 1, 1], :info)
-    @test_logs (:warn, vs)  is_vector(M, [1, 1], [-1, 1, 1], :warn)
+    @test_logs (:info, vs) is_vector(M, [1, 1], [-1, 1, 1], :info)
+    @test_logs (:warn, vs) is_vector(M, [1, 1], [-1, 1, 1], :warn)
     @test !is_vector(M, [1, 1, 1], [1, 1, 1], false, true)
     @test_throws DomainError is_vector(M, [1, 1, 1], [1, 1], true, true)
     @test_throws DomainError is_vector(M, [1, 1, 1], [1, 1], :error, true)
     ps2 = "DomainError with (3,)\nsize [1, 1, 1] not (2,)"
-    @test_logs (:info, ps2)  is_vector(M, [1, 1, 1], [1, 1], :info, true)
-    @test_logs (:warn, ps2)  is_vector(M, [1, 1, 1], [1, 1], :warn, true)
+    @test_logs (:info, ps2) is_vector(M, [1, 1, 1], [1, 1], :info, true)
+    @test_logs (:warn, ps2) is_vector(M, [1, 1, 1], [1, 1], :warn, true)
     @test is_vector(M, [1, 1], [1, 1])
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1], true)
 end

--- a/test/domain_errors.jl
+++ b/test/domain_errors.jl
@@ -64,4 +64,8 @@ end
     @test_logs (:warn, ps2) is_vector(M, [1, 1, 1], [1, 1], :warn, true)
     @test is_vector(M, [1, 1], [1, 1])
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1], true)
+    @test_throws DomainError is_vector(M, [1, 1], [-1, 1], :error, true)
+    ps3 = "DomainError with [-1, 1]\n<0"
+    @test_logs (:info, ps3) is_vector(M, [1, 1], [-1, 1], :info, true)
+    @test_logs (:warn, ps3) is_vector(M, [1, 1], [-1, 1], :warn, true)
 end

--- a/test/errors.jl
+++ b/test/errors.jl
@@ -33,4 +33,10 @@ using Test
     e6 = ManifoldDomainError("A.", e)
     s6 = sprint(showerror, e6)
     @test s6 == "ManifoldDomainError: A.\n$(s1)"
+
+    e7 = ApproximatelyError(1.0, "M.")
+    s7 = sprint(showerror, e7)
+    @test s7 == "ApproximatelyError with 1.0\nM.\n"
+    p7 = sprint(show, e7)
+    @test p7 == "ApproximatelyError(1.0, \"M.\")"
 end

--- a/test/validation_manifold.jl
+++ b/test/validation_manifold.jl
@@ -36,10 +36,10 @@ end
         @test ManifoldsBase.check_size(A, x2) === ManifoldsBase.check_size(M, x)
     end
     @testset "is_point / is_vector error." begin
-        @test is_point(M, x, :error)
-        @test_throws DomainError is_point(M, [1, 2, 3, 4], :error)
-        @test is_vector(M, x, v, :error)
-        @test_throws DomainError is_vector(M, x, [1, 2, 3, 4], :error)
+        @test is_point(A, x, :error)
+        @test_throws DomainError is_point(A, [1, 2, 3, 4], :error)
+        @test is_vector(A, x, v, :error)
+        @test_throws DomainError is_vector(A, x, [1, 2, 3, 4], :error)
     end
     @testset "Types and Conversion" begin
         @test convert(typeof(M), A) == M

--- a/test/validation_manifold.jl
+++ b/test/validation_manifold.jl
@@ -35,6 +35,12 @@ end
         @test ManifoldsBase.check_size(A, x2, v2) === ManifoldsBase.check_size(M, x, v)
         @test ManifoldsBase.check_size(A, x2) === ManifoldsBase.check_size(M, x)
     end
+    @testset "Is_point / is_vector error." begin
+        @test is_point(M, x, :error)
+        @test_throws DomainError is_point(M, [1, 2, 3, 4], :error)
+        @test is_vector(M, x, v, :error)
+        @test_throws DomainError is_vector(M, x, [1, 2, 3, 4], :error)
+    end
     @testset "Types and Conversion" begin
         @test convert(typeof(M), A) == M
         @test convert(typeof(A), M) == A

--- a/test/validation_manifold.jl
+++ b/test/validation_manifold.jl
@@ -35,7 +35,7 @@ end
         @test ManifoldsBase.check_size(A, x2, v2) === ManifoldsBase.check_size(M, x, v)
         @test ManifoldsBase.check_size(A, x2) === ManifoldsBase.check_size(M, x)
     end
-    @testset "Is_point / is_vector error." begin
+    @testset "is_point / is_vector error." begin
         @test is_point(M, x, :error)
         @test_throws DomainError is_point(M, [1, 2, 3, 4], :error)
         @test is_vector(M, x, v, :error)


### PR DESCRIPTION
I.e. that the following methods have symbol positional arguments 

* [x] `is_point`
* [x] `is_vector`
* [x] `isapprox` (with manifolds)
* [x] these are tested (and ambiguities are resolved)

This resolves #131.

I am not yet sure how to do the tests (I am not able to use `@test_logs` here and the actual info/warn string for `isapprox` seems to be a little difficult still.

_edit:_ Oh and I introduced quite a few ambiguities, all but 3 I could resolve, those are special ones with the embedding and might be a little tricky.