### PR TITLE
More method specializations for `allocate_result`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.25"
+version = "0.13.26"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -88,7 +88,11 @@ get_embedding(M::AbstractDecoratorManifold, p) = get_embedding(M)
 
 # Introduction and default fallbacks could become a macro?
 # Introduce trait
-function allocate_result(M::AbstractDecoratorManifold, f, x...)
+@inline function allocate_result(
+    M::AbstractDecoratorManifold,
+    f::TF,
+    x::Vararg{Any,N},
+) where {TF,N}
     return allocate_result(trait(allocate_result, M, f, x...), M, f, x...)
 end
 # disambiguation
@@ -101,7 +105,12 @@ end
 )
 
 # Introduce fallback
-@inline function allocate_result(::EmptyTrait, M::AbstractManifold, f, x...)
+@inline function allocate_result(
+    ::EmptyTrait,
+    M::AbstractManifold,
+    f::TF,
+    x::Vararg{Any,N},
+) where {TF,N}
     return invoke(
         allocate_result,
         Tuple{AbstractManifold,typeof(f),typeof(x).parameters...},
@@ -111,15 +120,20 @@ end
     )
 end
 # Introduce automatic forward
-@inline function allocate_result(t::TraitList, M::AbstractManifold, f, x...)
+@inline function allocate_result(
+    t::TraitList,
+    M::AbstractManifold,
+    f::TF,
+    x::Vararg{Any,N},
+) where {TF,N}
     return allocate_result(next_trait(t), M, f, x...)
 end
 function allocate_result(
     ::TraitList{IsEmbeddedManifold},
     M::AbstractDecoratorManifold,
     f::typeof(embed),
-    x...,
-)
+    x::Vararg{Any,N},
+) where {N}
     T = allocate_result_type(get_embedding(M, x[1]), f, x)
     return allocate(M, x[1], T, representation_size(get_embedding(M, x[1])))
 end
@@ -127,17 +141,17 @@ function allocate_result(
     ::TraitList{IsEmbeddedManifold},
     M::AbstractDecoratorManifold,
     f::typeof(project),
-    x...,
-)
+    x::Vararg{Any,N},
+) where {N}
     T = allocate_result_type(get_embedding(M, x[1]), f, x)
     return allocate(M, x[1], T, representation_size(M))
 end
 @inline function allocate_result(
     ::TraitList{IsExplicitDecorator},
     M::AbstractDecoratorManifold,
-    f,
-    x...,
-)
+    f::TF,
+    x::Vararg{Any,N},
+) where {TF,N}
     return allocate_result(decorated_manifold(M), f, x...)
 end
 


### PR DESCRIPTION
We have an unfortunate side-effect of our trait system. Method recursion prevents some type inference from happening around, for example, `allocate_result`. This can cause massive slow-downs, for example the current Manifolds.jl does 32 allocations to copy a point on `SpecialOrthogonal(3)`. This PR solves this partially -- with these changes it's now just 4 -- but we will have to introduce specialized methods to work around inefficiencies in some key parts. I don't really see how to improve it further generically.