### PR TITLE
Don't inline `invoke` in a generic fallback.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,9 @@ jobs:
       matrix:
         julia-version: ["1.0", "1.6", "1.7", "1.8"]
         os: [ubuntu-latest, macOS-latest, windows-latest]
+        exclude:
+          - os: macOS-latest
+            julia-version: "1.0"
     steps:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@v1

--- a/src/ValidationManifold.jl
+++ b/src/ValidationManifold.jl
@@ -198,8 +198,8 @@ function get_basis(
         Any,
         Union{
             AbstractOrthogonalBasis,
-            CachedBasis{𝔽,<:AbstractOrthogonalBasis{𝔽}},
-        } where {𝔽},
+            CachedBasis{𝔽2,<:AbstractOrthogonalBasis{𝔽2}},
+        } where {𝔽2},
     }
     Ξ = invoke(get_basis, get_basis_invoke_types, M, p, B; kwargs...)
     bvectors = get_vectors(M, p, Ξ)

--- a/src/nested_trait.jl
+++ b/src/nested_trait.jl
@@ -300,6 +300,8 @@ macro trait_function(sig, opts = :())
     if !(:no_empty in opts.args)
         block = quote
             $block
+            # See https://discourse.julialang.org/t/extremely-slow-invoke-when-inlined/90665
+            # for the reasoning behind @noinline
             @noinline function ($fname)(
                 ::EmptyTrait,
                 $(callargs...);

--- a/src/nested_trait.jl
+++ b/src/nested_trait.jl
@@ -300,7 +300,7 @@ macro trait_function(sig, opts = :())
     if !(:no_empty in opts.args)
         block = quote
             $block
-            @inline function ($fname)(
+            @noinline function ($fname)(
                 ::EmptyTrait,
                 $(callargs...);
                 $(kwargs_list...),


### PR DESCRIPTION
Workaround for https://discourse.julialang.org/t/extremely-slow-invoke-when-inlined/90665 .