### PR TITLE
Introduce rand(M) and rand!(M, p) to the API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.27"
+version = "0.13.28"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.13.27"
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Markdown = "d6f4376e-aef5-505a-96c1-9c027394607a"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [compat]
 DoubleFloats = ">= 0.9.2"

--- a/src/DefaultManifold.jl
+++ b/src/DefaultManifold.jl
@@ -132,6 +132,21 @@ function parallel_transport_to!(::DefaultManifold, Y, p, X, q)
     return copyto!(Y, X)
 end
 
+function Random.rand!(::DefaultManifold, pX; σ = one(eltype(pX)), vector_at = nothing)
+    pX .= randn(size(pX)) .* σ
+    return pX
+end
+function Random.rand!(
+    rng::AbstractRNG,
+    ::DefaultManifold,
+    pX;
+    σ = one(eltype(pX)),
+    vector_at = nothing,
+)
+    pX .= randn(rng, size(pX)) .* σ
+    return pX
+end
+
 function riemann_tensor!(::DefaultManifold, Xresult, p, X, Y, Z)
     return fill!(Xresult, 0)
 end

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -19,8 +19,11 @@ import Base:
     ==
 import LinearAlgebra: dot, norm, det, cross, I, UniformScaling, Diagonal
 
+import Random: rand
+
 import Markdown: @doc_str
 using LinearAlgebra
+using Random
 
 include("maintypes.jl")
 include("numbers.jl")
@@ -736,6 +739,44 @@ end
     return typeof(sum(map(eti_to_one, x)))
 end
 
+"""
+    Random.rand(M::AbstractManifold, [d::Integer]; vector_at=nothing)
+    Random.rand(rng::AbstractRNG, M::AbstractManifold, [d::Integer]; vector_at=nothing)
+
+
+Generate a random point on manifold `M` (when `vector_at` is `nothing`) or a tangent
+vector at point `vector_at` (when it is not `nothing`).
+
+Optionally a random number generator `rng` to be used can be specified. An optional integer
+`d` indicates that a vector of `d` points or tangent vectors is to be generated.
+
+!!! note
+
+    Usually a uniform distribution should be expected for compact manifolds and a
+    Gaussian-like distribution for non-compact manifolds and tangent vectors, although it is
+    not guaranteed. The distribution may change between releases.
+
+    `rand` methods for specific manifolds may take additional keyword arguments.
+
+"""
+Random.rand(M::AbstractManifold)
+function Random.rand(M::AbstractManifold, d::Integer; kwargs...)
+    return [rand(M; kwargs...) for _ in 1:d]
+end
+function Random.rand(rng::AbstractRNG, M::AbstractManifold, d::Integer; kwargs...)
+    return [rand(rng, M; kwargs...) for _ in 1:d]
+end
+function Random.rand(M::AbstractManifold; kwargs...)
+    p = allocate_result(M, rand)
+    rand!(M, p; kwargs...)
+    return p
+end
+function Random.rand(rng::AbstractRNG, M::AbstractManifold; kwargs...)
+    p = allocate_result(M, rand)
+    rand!(rng, M, p; kwargs...)
+    return p
+end
+
 @doc raw"""
     representation_size(M::AbstractManifold)
 
@@ -930,6 +971,7 @@ export allocate,
     shortest_geodesic,
     shortest_geodesic!,
     show,
+    rand,
     retract,
     retract!,
     riemann_tensor,

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -19,7 +19,7 @@ import Base:
     ==
 import LinearAlgebra: dot, norm, det, cross, I, UniformScaling, Diagonal
 
-import Random: rand
+import Random: rand, rand!
 
 import Markdown: @doc_str
 using LinearAlgebra

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -1036,6 +1036,78 @@ function project!(M::PowerManifoldNestedReplacing, Z, q, Y)
     return Z
 end
 
+function Random.rand!(M::AbstractPowerManifold, pX; vector_at = nothing, kwargs...)
+    rep_size = representation_size(M.manifold)
+    if vector_at === nothing
+        for i in get_iterator(M)
+            rand!(M.manifold, _write(M, rep_size, pX, i))
+        end
+    else
+        for i in get_iterator(M)
+            rand!(
+                M.manifold,
+                _write(M, rep_size, pX, i);
+                vector_at = _read(M, rep_size, vector_at, i),
+            )
+        end
+    end
+    return pX
+end
+function Random.rand!(
+    rng::AbstractRNG,
+    M::AbstractPowerManifold,
+    pX;
+    vector_at = nothing,
+    kwargs...,
+)
+    rep_size = representation_size(M.manifold)
+    if vector_at === nothing
+        for i in get_iterator(M)
+            rand!(rng, M.manifold, _write(M, rep_size, pX, i))
+        end
+    else
+        for i in get_iterator(M)
+            rand!(
+                rng,
+                M.manifold,
+                _write(M, rep_size, pX, i);
+                vector_at = _read(M, rep_size, vector_at, i),
+            )
+        end
+    end
+    return pX
+end
+function Random.rand!(M::PowerManifoldNestedReplacing, pX; vector_at = nothing, kwargs...)
+    if vector_at === nothing
+        for i in get_iterator(M)
+            pX[i...] = rand(M.manifold; kwargs...)
+        end
+    else
+        for i in get_iterator(M)
+            pX[i...] = rand(M.manifold; vector_at = vector_at[i...], kwargs...)
+        end
+    end
+    return pX
+end
+function Random.rand!(
+    rng::AbstractRNG,
+    M::PowerManifoldNestedReplacing,
+    pX;
+    vector_at = nothing,
+    kwargs...,
+)
+    if vector_at === nothing
+        for i in get_iterator(M)
+            pX[i...] = rand(rng, M.manifold; kwargs...)
+        end
+    else
+        for i in get_iterator(M)
+            pX[i...] = rand(rng, M.manifold; vector_at = vector_at[i...], kwargs...)
+        end
+    end
+    return pX
+end
+
 Base.@propagate_inbounds @inline function _read(
     M::AbstractPowerManifold,
     rep_size::Tuple,

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -571,9 +571,9 @@ end
 
 @trait_function Random.rand!(M::AbstractDecoratorManifold, p; kwargs...)
 
-@trait_function Random.rand(rng::AbstractRNG, M::AbstractDecoratorManifold; kwargs...)
+@trait_function Random.rand(rng::AbstractRNG, M::AbstractDecoratorManifold; kwargs...) :() 2
 
-@trait_function Random.rand!(rng::AbstractRNG, M::AbstractDecoratorManifold, p; kwargs...)
+@trait_function Random.rand!(rng::AbstractRNG, M::AbstractDecoratorManifold, p; kwargs...) :() 2
 
 # Introduce Deco Trait | automatic foward | fallback
 @trait_function representation_size(M::AbstractDecoratorManifold) (no_empty,)

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -567,6 +567,14 @@ end
 # Introduce Deco Trait | automatic foward | fallback
 @trait_function project!(M::AbstractDecoratorManifold, Y, p, X)
 
+@trait_function Random.rand(M::AbstractDecoratorManifold; kwargs...)
+
+@trait_function Random.rand!(M::AbstractDecoratorManifold, p; kwargs...)
+
+@trait_function Random.rand(rng::AbstractRNG, M::AbstractDecoratorManifold; kwargs...)
+
+@trait_function Random.rand!(rng::AbstractRNG, M::AbstractDecoratorManifold, p; kwargs...)
+
 # Introduce Deco Trait | automatic foward | fallback
 @trait_function representation_size(M::AbstractDecoratorManifold) (no_empty,)
 # Isometric Embedded submanifold

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -14,10 +14,12 @@ import ManifoldsBase:
     parallel_transport_to!,
     retract!,
     inverse_retract!
+
 import Base: angle, convert
-using LinearAlgebra
 using DoubleFloats
 using ForwardDiff
+using LinearAlgebra
+using Random
 using ReverseDiff
 using StaticArrays
 using Test
@@ -415,6 +417,34 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
                 @test isapprox(M, pts[1], tv, tv1)
             end
 
+            @testset "randon tests" begin
+                Random.seed!(23)
+                pr = rand(M)
+                @test is_point(M, pr, true)
+                Xr = rand(M; vector_at = pr)
+                @test is_vector(M, pr, Xr, true)
+                rng = MersenneTwister(42)
+                P = rand(M, 3)
+                @test length(P) == 3
+                @test all([is_point(M, pj) for pj in P])
+                Xv = rand(M, 3; vector_at = pr)
+                @test length(Xv) == 3
+                @test all([is_point(M, Xj) for Xj in Xv])
+                # and the same again with rng upfront
+                rng = MersenneTwister(42)
+                pr = rand(rng, M)
+                @test is_point(M, pr, true)
+                Xr = rand(rng, M; vector_at = pr)
+                @test is_vector(M, pr, Xr, true)
+                rng = MersenneTwister(42)
+                P = rand(rng, M, 3)
+                @test length(P) == 3
+                @test all([is_point(M, pj) for pj in P])
+                Xv = rand(rng, M, 3; vector_at = pr)
+                @test length(Xv) == 3
+                @test all([is_point(M, Xj) for Xj in Xv])
+            end
+
             @testset "vector transport" begin
                 # test constructor
                 @test default_vector_transport_method(M) == ParallelTransport()
@@ -600,6 +630,7 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
         p2 = copy(p1)
         @test (p1 == p2) && (p1 !== p2)
     end
+
     @testset "further vector and point automatic forwards" begin
         M = ManifoldsBase.DefaultManifold(3)
         p = DefaultPoint([1.0, 0.0, 0.0])
@@ -717,6 +748,7 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
         @test parallel_transport_direction!(M, Y, p, X, X) == X
         @test parallel_transport_along!(M, Y, p, X, []) == X
     end
+
     @testset "DefaultManifold and ONB" begin
         M = ManifoldsBase.DefaultManifold(3)
         p = [1.0f0, 0.0f0, 0.0f0]
@@ -736,10 +768,12 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
         CBR = get_basis(MC, p, DefaultOrthonormalBasis())
         @test CBR.data == [[1.0, 0.0, 0.0], [0.0, 1.0, 0.0], [0.0, 0.0, 1.0]]
     end
+
     @testset "Show methods" begin
         @test repr(CayleyRetraction()) == "CayleyRetraction()"
         @test repr(PadeRetraction(2)) == "PadeRetraction(2)"
     end
+
     @testset "Further TestArrayRepresentation" begin
         M = ManifoldsBase.DefaultManifold(3)
         p = [1.0, 0.0, 0.0]

--- a/test/passthrough_decorator.jl
+++ b/test/passthrough_decorator.jl
@@ -1,6 +1,7 @@
 
 using ManifoldsBase
 using Test
+using Random
 
 using ManifoldsBase: TraitList, merge_traits
 
@@ -11,6 +12,9 @@ struct PassthroughDecorator{𝔽,MT<:AbstractManifold{𝔽}} <: AbstractDecorato
 end
 
 function ManifoldsBase.active_traits(f, ::PassthroughDecorator, ::Any...)
+    return merge_traits(PassthoughTrait())
+end
+function ManifoldsBase.active_traits(f, ::AbstractRNG, ::PassthroughDecorator, ::Any...)
     return merge_traits(PassthoughTrait())
 end
 
@@ -33,6 +37,28 @@ function ManifoldsBase.exp!(
     return log!(M.manifold, q, p, X)
 end
 
+function ManifoldsBase.rand(::TraitList{PassthoughTrait}, M::AbstractDecoratorManifold)
+    return rand(M.manifold)
+end
+function ManifoldsBase.rand!(::TraitList{PassthoughTrait}, M::AbstractDecoratorManifold, p)
+    return rand!(M.manifold, p)
+end
+function ManifoldsBase.rand(
+    ::TraitList{PassthoughTrait},
+    rng::AbstractRNG,
+    M::AbstractDecoratorManifold,
+)
+    return rand(rng, M.manifold)
+end
+function ManifoldsBase.rand!(
+    ::TraitList{PassthoughTrait},
+    rng::AbstractRNG,
+    M::AbstractDecoratorManifold,
+    p,
+)
+    return rand!(rng, M.manifold, p)
+end
+
 @testset "PassthroughDecorator" begin
     M = PassthroughDecorator(ManifoldsBase.DefaultManifold(2))
 
@@ -43,4 +69,12 @@ end
     @test inverse_retract!(M, q, p, X) == [1.0, 2.0]
     @test retract(M, p, q) == [1.0, 2.0]
     @test retract!(M, Y, p, q) == [1.0, 2.0]
+    @test rand(M) isa Vector{Float64}
+    p2 = similar(p)
+    rand!(M, p2)
+    @test p2 isa Vector{Float64}
+    @test rand(MersenneTwister(123), M) isa Vector{Float64}
+    p2 = similar(p)
+    rand!(MersenneTwister(123), M, p2)
+    @test p2 == rand(MersenneTwister(123), M)
 end

--- a/test/power.jl
+++ b/test/power.jl
@@ -3,6 +3,7 @@ using ManifoldsBase
 using ManifoldsBase: AbstractNumbers, ℝ, ℂ, NestedReplacingPowerRepresentation
 using StaticArrays
 using LinearAlgebra
+using Random
 
 power_array_wrapper(::Type{NestedPowerRepresentation}, ::Int) = identity
 power_array_wrapper(::Type{NestedReplacingPowerRepresentation}, i::Int) = SVector{i}
@@ -268,6 +269,26 @@ struct TestArrayRepresentation <: AbstractPowerRepresentation end
                 @test p[N, 1] == 1.0
                 @test zero_vector(N, p) == zero(p)
             end
+        end
+    end
+
+    @testset "Power RNG" begin
+        M = ManifoldsBase.DefaultManifold(3)
+        for rep in [NestedPowerRepresentation(), NestedReplacingPowerRepresentation()]
+            N = PowerManifold(M, rep, 2)
+            @test is_point(N, rand(N))
+            @test is_point(N, rand(MersenneTwister(123), N))
+            @test rand(MersenneTwister(123), N) == rand(MersenneTwister(123), N)
+            p = rand(N)
+            @test is_vector(N, p, rand(N; vector_at = p); atol = 1e-15)
+            @test is_vector(
+                N,
+                p,
+                rand(MersenneTwister(123), N; vector_at = p);
+                atol = 1e-15,
+            )
+            @test rand(MersenneTwister(123), N; vector_at = p) ==
+                  rand(MersenneTwister(123), N; vector_at = p)
         end
     end
 end


### PR DESCRIPTION
This PR adapts the existing methods from Manifolds.jl to ManifoldsBase.jl.

Things to check / discuss
* [x] should we make both functions aware of decorators? Especially for the `rand(rng, M)` variants this might be challenging, but I thing that might be cool to have.
* [x] Should we also provide a default implementation for the Power manifold?
* [x] ~Should we also provide an implementation in the embedding (rand in embedding & project)?~