### PR TITLE
Add `is_flat` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.29"
+version = "0.13.30"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/DefaultManifold.jl
+++ b/src/DefaultManifold.jl
@@ -109,6 +109,8 @@ injectivity_radius(::DefaultManifold) = Inf
 
 @inline inner(::DefaultManifold, p, X, Y) = dot(X, Y)
 
+is_flat(::DefaultManifold) = true
+
 log!(::DefaultManifold, Y, p, q) = (Y .= q .- p)
 
 @generated function manifold_dimension(::DefaultManifold{T,𝔽}) where {T,𝔽}

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -482,6 +482,14 @@ Compute the inner product of tangent vectors `X` and `Y` at point `p` from the
 inner(M::AbstractManifold, p, X, Y)
 
 """
+    is_flat(M::AbstractManifold)
+
+Return true if the [`AbstractManifold`](@ref) `M` is flat, i.e. if its Riemann curvature
+tensor is everywhere zero.
+"""
+is_flat(M::AbstractManifold)
+
+"""
     isapprox(M::AbstractManifold, p, q; error::Symbol=none, kwargs...)
 
 Check if points `p` and `q` from [`AbstractManifold`](@ref) `M` are approximately equal.
@@ -944,6 +952,7 @@ export allocate,
     inverse_retract,
     inverse_retract!,
     isapprox,
+    is_flat,
     is_point,
     is_vector,
     isempty,

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -343,6 +343,8 @@ end
 @trait_function isapprox(M::AbstractDecoratorManifold, p, q; kwargs...)
 @trait_function isapprox(M::AbstractDecoratorManifold, p, X, Y; kwargs...)
 
+@trait_function is_flat(M::AbstractDecoratorManifold)
+
 # Introduce Deco Trait | automatic foward | fallback
 @trait_function is_point(M::AbstractDecoratorManifold, p, te::Bool = false; kwargs...)
 @trait_function is_point(M::AbstractDecoratorManifold, p, e::Symbol; kwargs...)

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -230,6 +230,8 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
     @test default_retraction_method(M) == ExponentialRetraction()
     @test default_inverse_retraction_method(M) == LogarithmicInverseRetraction()
 
+    @test is_flat(M)
+
     rm = ManifoldsBase.ExponentialRetraction()
     irm = ManifoldsBase.LogarithmicInverseRetraction()
 


### PR DESCRIPTION
This is needed to correctly implement injectivity radius for tangent bundle, which is then needed to fix Manopt line search on tangent bundle.