### PR TITLE
Introduce the idea of the more-precise default functions from (#144).

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.13.29"
+version = "0.13.30"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -83,7 +83,7 @@ To close this section, let‘s look at an example.
 The high level (or [Layer I](@ref design-layer1)) definition of the retraction is given by
 
 ```julia
-retract(M::AbstractManifold, p, X, m::AbstractRetractionMethod=default_retraction_method(M)) = _retract(M, p, X, m)
+retract(M::AbstractManifold, p, X, m::AbstractRetractionMethod=default_retraction_method(M, typeof(p))) = _retract(M, p, X, m)
 ```
 
 This level now dispatches on different retraction types `m`.

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -376,6 +376,9 @@ functions defined for the power manifold, meaning that this is used elementwise.
 function default_retraction_method(M::PowerManifold)
     return default_retraction_method(M.manifold)
 end
+function default_retraction_method(M::PowerManifold, t::Type)
+    return default_retraction_method(M.manifold, t)
+end
 
 @doc raw"""
     default_inverse_retraction_method(M::PowerManifold)
@@ -386,6 +389,9 @@ functions defined for the power manifold, meaning that this is used elementwise.
 function default_inverse_retraction_method(M::PowerManifold)
     return default_inverse_retraction_method(M.manifold)
 end
+function default_inverse_retraction_method(M::PowerManifold, t::Type)
+    return default_inverse_retraction_method(M.manifold, t)
+end
 
 @doc raw"""
     default_vector_transport_method(M::PowerManifold)
@@ -395,6 +401,9 @@ functions defined for the power manifold, meaning that this is used elementwise.
 """
 function default_vector_transport_method(M::PowerManifold)
     return default_vector_transport_method(M.manifold)
+end
+function default_vector_transport_method(M::PowerManifold, t::Type)
+    return default_vector_transport_method(M.manifold, t)
 end
 
 @doc raw"""
@@ -775,7 +784,7 @@ function inverse_retract(
     M::AbstractPowerManifold,
     p,
     q,
-    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M),
+    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
 )
     X = allocate_result(M, inverse_retract, p, q)
     return inverse_retract!(M, X, p, q, m)
@@ -786,7 +795,7 @@ function inverse_retract!(
     X,
     p,
     q,
-    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M),
+    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
 )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -805,7 +814,7 @@ function inverse_retract!(
     X,
     p,
     q,
-    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M),
+    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
 )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1146,7 +1155,7 @@ function retract(
     M::AbstractPowerManifold,
     p,
     X,
-    m::AbstractRetractionMethod = default_retraction_method(M),
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
 )
     q = allocate_result(M, retract, p, X)
     return retract!(M, q, p, X, m)
@@ -1157,7 +1166,7 @@ function retract!(
     q,
     p,
     X,
-    m::AbstractRetractionMethod = default_retraction_method(M),
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
 )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1176,7 +1185,7 @@ function retract!(
     q,
     p,
     X,
-    m::AbstractRetractionMethod = default_retraction_method(M),
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
 )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1278,7 +1287,7 @@ function vector_transport_direction!(
     p,
     X,
     d,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1298,7 +1307,7 @@ function vector_transport_direction(
     p,
     X,
     d,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     Y = allocate_result(M, vector_transport_direction, p, X, d)
     return vector_transport_direction!(M, Y, p, X, d, m)
@@ -1310,7 +1319,7 @@ function vector_transport_direction!(
     p,
     X,
     d,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1329,7 +1338,7 @@ function vector_transport_direction(
     p,
     X,
     d,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     Y = allocate_result(M, vector_transport_direction, p, X, d)
     rep_size = representation_size(M.manifold)
@@ -1365,7 +1374,7 @@ function vector_transport_to(
     p,
     X,
     q,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     Y = allocate_result(M, vector_transport_to, p, X)
     return vector_transport_to!(M, Y, p, X, q, m)
@@ -1376,7 +1385,7 @@ function vector_transport_to!(
     p,
     X,
     q,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1397,7 +1406,7 @@ function vector_transport_to!(
     p,
     X,
     q,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -377,7 +377,7 @@ function default_retraction_method(M::PowerManifold)
     return default_retraction_method(M.manifold)
 end
 function default_retraction_method(M::PowerManifold, t::Type)
-    return default_retraction_method(M.manifold, t)
+    return default_retraction_method(M.manifold, eltype(t))
 end
 
 @doc raw"""

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -390,7 +390,7 @@ function default_inverse_retraction_method(M::PowerManifold)
     return default_inverse_retraction_method(M.manifold)
 end
 function default_inverse_retraction_method(M::PowerManifold, t::Type)
-    return default_inverse_retraction_method(M.manifold, t)
+    return default_inverse_retraction_method(M.manifold, eltype(t))
 end
 
 @doc raw"""

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -403,7 +403,7 @@ function default_vector_transport_method(M::PowerManifold)
     return default_vector_transport_method(M.manifold)
 end
 function default_vector_transport_method(M::PowerManifold, t::Type)
-    return default_vector_transport_method(M.manifold, t)
+    return default_vector_transport_method(M.manifold, eltype(t))
 end
 
 @doc raw"""

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -307,7 +307,7 @@ end
     M::AbstractDecoratorManifold,
     p,
     q,
-    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M),
+    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
 )
 # Transparent for Submanifolds
 function inverse_retract(
@@ -315,7 +315,7 @@ function inverse_retract(
     M::AbstractDecoratorManifold,
     p,
     q,
-    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M),
+    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
 )
     return inverse_retract(get_embedding(M, p), p, q, m)
 end
@@ -335,7 +335,7 @@ function inverse_retract!(
     X,
     p,
     q,
-    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M),
+    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
 )
     return inverse_retract!(get_embedding(M, p), X, p, q, m)
 end
@@ -591,14 +591,14 @@ end
     M::AbstractDecoratorManifold,
     p,
     X,
-    m::AbstractRetractionMethod = default_retraction_method(M),
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
 )
 function retract(
     ::TraitList{IsEmbeddedSubmanifold},
     M::AbstractDecoratorManifold,
     p,
     X,
-    m::AbstractRetractionMethod = default_retraction_method(M),
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
 )
     return retract(get_embedding(M, p), p, X, m)
 end
@@ -608,7 +608,7 @@ end
     q,
     p,
     X,
-    m::AbstractRetractionMethod = default_retraction_method(M),
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
 )
 function retract!(
     ::TraitList{IsEmbeddedSubmanifold},
@@ -616,7 +616,7 @@ function retract!(
     q,
     p,
     X,
-    m::AbstractRetractionMethod = default_retraction_method(M),
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
 )
     return retract!(get_embedding(M, p), q, p, X, m)
 end
@@ -626,7 +626,7 @@ end
     q,
     p,
     X,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
 function vector_transport_along(
     ::TraitList{IsEmbeddedSubmanifold},
@@ -634,7 +634,7 @@ function vector_transport_along(
     p,
     X,
     c,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     return vector_transport_along(get_embedding(M, p), p, X, c, m)
 end
@@ -645,7 +645,7 @@ end
     p,
     X,
     c::AbstractVector,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
 function vector_transport_along!(
     ::TraitList{IsEmbeddedSubmanifold},
@@ -654,7 +654,7 @@ function vector_transport_along!(
     p,
     X,
     c::AbstractVector,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     return vector_transport_along!(get_embedding(M, p), Y, p, X, c, m)
 end
@@ -664,7 +664,7 @@ end
     p,
     X,
     d,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
 function vector_transport_direction(
     ::TraitList{IsEmbeddedSubmanifold},
@@ -672,7 +672,7 @@ function vector_transport_direction(
     p,
     X,
     d,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     return vector_transport_direction(get_embedding(M, p), p, X, d, m)
 end
@@ -683,7 +683,7 @@ end
     p,
     X,
     d,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
 function vector_transport_direction!(
     ::TraitList{IsEmbeddedSubmanifold},
@@ -692,7 +692,7 @@ function vector_transport_direction!(
     p,
     X,
     d,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     return vector_transport_direction!(get_embedding(M, p), Y, p, X, d, m)
 end
@@ -702,7 +702,7 @@ end
     p,
     X,
     q,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
 function vector_transport_to(
     ::TraitList{IsEmbeddedSubmanifold},
@@ -710,7 +710,7 @@ function vector_transport_to(
     p,
     X,
     q,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     return vector_transport_to(get_embedding(M, p), p, X, q, m)
 end
@@ -721,7 +721,7 @@ end
     p,
     X,
     q,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
 function vector_transport_to!(
     ::TraitList{IsEmbeddedSubmanifold},
@@ -730,7 +730,7 @@ function vector_transport_to!(
     p,
     X,
     q,
-    m::AbstractVectorTransportMethod = default_vector_transport_method(M),
+    m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
 )
     return vector_transport_to!(get_embedding(M, p), Y, p, X, q, m)
 end

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -347,7 +347,7 @@ struct SoftmaxInverseRetraction <: AbstractInverseRetractionMethod end
 
 """
     default_inverse_retraction_method(M::AbstractManifold)
-    default_inverse_retraction_method(M::AbstractManifold, ::Type{T}) where {T})
+    default_inverse_retraction_method(M::AbstractManifold, ::Type{T}) where {T}
 
 The [`AbstractInverseRetractionMethod`](@ref) that is used when calling
 [`inverse_retract`](@ref) without specifying the inverse retraction method.

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -347,20 +347,36 @@ struct SoftmaxInverseRetraction <: AbstractInverseRetractionMethod end
 
 """
     default_inverse_retraction_method(M::AbstractManifold)
+    default_inverse_retraction_method(M::AbstractManifold, ::Type{T}) where {T})
 
 The [`AbstractInverseRetractionMethod`](@ref) that is used when calling
 [`inverse_retract`](@ref) without specifying the inverse retraction method.
 By default, this is the [`LogarithmicInverseRetraction`](@ref).
+
+This method can also be specified more precisely with a point type `T`, for the case
+that on a `M` there are two different representations of points, which provide
+different inverse retraction methods.
 """
 default_inverse_retraction_method(::AbstractManifold) = LogarithmicInverseRetraction()
+function default_inverse_retraction_method(M::AbstractManifold, ::Type{T}) where {T}
+    return default_inverse_retraction_method(M)
+end
 
 """
     default_retraction_method(M::AbstractManifold)
+    default_retraction_method(M::AbstractManifold, ::Type{T}) where {T}
 
 The [`AbstractRetractionMethod`](@ref) that is used when calling [`retract`](@ref) without
 specifying the retraction method. By default, this is the [`ExponentialRetraction`](@ref).
+
+This method can also be specified more precisely with a point type `T`, for the case
+that on a `M` there are two different representations of points, which provide
+different retraction methods.
 """
 default_retraction_method(::AbstractManifold) = ExponentialRetraction()
+function default_retraction_method(M::AbstractManifold, ::Type{T}) where {T}
+    return default_retraction_method(M)
+end
 
 """
     inverse_retract!(M::AbstractManifold, X, p, q[, method::AbstractInverseRetractionMethod])
@@ -380,7 +396,7 @@ function inverse_retract!(
     X,
     p,
     q,
-    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M),
+    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
 )
     return _inverse_retract!(M, X, p, q, m)
 end
@@ -589,7 +605,7 @@ function inverse_retract(
     M::AbstractManifold,
     p,
     q,
-    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M),
+    m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
 )
     return _inverse_retract(M, p, q, m)
 end
@@ -778,7 +794,7 @@ function retract!(
     q,
     p,
     X,
-    m::AbstractRetractionMethod = default_retraction_method(M),
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
 )
     return _retract!(M, q, p, X, m)
 end
@@ -788,7 +804,7 @@ function retract!(
     p,
     X,
     t::Real,
-    method::AbstractRetractionMethod = default_retraction_method(M),
+    method::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
 )
     return retract!(M, q, p, t * X, method)
 end
@@ -924,8 +940,8 @@ retract_softmax!(M::AbstractManifold, q, p, X)
 function retract_softmax! end
 
 @doc raw"""
-    retract(M::AbstractManifold, p, X, method::AbstractRetractionMethod=default_retraction_method(M))
-    retract(M::AbstractManifold, p, X, t::Real=1, method::AbstractRetractionMethod=default_retraction_method(M))
+    retract(M::AbstractManifold, p, X, method::AbstractRetractionMethod=default_retraction_method(M, typeof(p)))
+    retract(M::AbstractManifold, p, X, t::Real=1, method::AbstractRetractionMethod=default_retraction_method(M, typeof(p)))
 
 Compute a retraction, a cheaper, approximate version of the [`exp`](@ref)onential map,
 from `p` into direction `X`, scaled by `t`, on the [`AbstractManifold`](@ref) `M`.
@@ -950,7 +966,7 @@ function retract(
     M::AbstractManifold,
     p,
     X,
-    m::AbstractRetractionMethod = default_retraction_method(M),
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
 )
     return _retract(M, p, X, m)
 end
@@ -959,7 +975,7 @@ function retract(
     p,
     X,
     t::Real,
-    m::AbstractRetractionMethod = default_retraction_method(M),
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
 )
     return retract(M, p, t * X, m)
 end


### PR DESCRIPTION
Let me know what you think.

Maybe `default_X_method(M, typeof(p))` looks a little clumsy, but I feel to emphasise that it should never depend on the **values** of `p` really only on its type. We should not change the default “locally” but based on representation.

The application example from Manifolds.jl is the Grassmann manifold, where we should only set a default for the Array/Stiefel representation (to be `ProjectionRetraction`) but not for the Projection representation, where no vector transport is implemented.

This is non-breaking, since the 2-argument version falls back to the 1-argument one – but making use of this more-precise dispatch requires a bit of patching in Manifolds and Manopt.