### PR TITLE
Introduce change_representer already in ManifoldsBase

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.14.0"
+version = "0.14.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/DefaultManifold.jl
+++ b/src/DefaultManifold.jl
@@ -16,6 +16,10 @@ function DefaultManifold(n::Vararg{Int}; field = ℝ)
     return DefaultManifold{field,typeof(n)}(n)
 end
 
+change_representer!(M::DefaultManifold, Y, ::EuclideanMetric, p, X) = copyto!(M, Y, p, X)
+
+change_metric!(M::DefaultManifold, Y, ::EuclideanMetric, p, X) = copyto!(M, Y, p, X)
+
 function check_approx(M::DefaultManifold, p, q; kwargs...)
     res = isapprox(p, q; kwargs...)
     res && return nothing

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -616,7 +616,7 @@ end
 An internal function for testing whether tangent vectors `X` and `Y` from tangent space
 at point `p` from manifold `M` are approximately equal. Returns either `true` or `false`
 and does not support errors like [`isapprox`](@ref).
-    
+
 For more details see documentation of [`check_approx`](@ref).
 """
 function _isapprox(M::AbstractManifold, p, X, Y; kwargs...)
@@ -991,6 +991,10 @@ export allocate,
     base_manifold,
     change_basis,
     change_basis!,
+    change_metric,
+    change_metric!,
+    change_representer,
+    change_representer!,
     copy,
     copyto!,
     default_inverse_retraction_method,

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -156,6 +156,18 @@ end
 end
 
 
+@trait_function change_metric(M::AbstractDecoratorManifold, G::AbstractMetric, X, p)
+@trait_function change_metric!(M::AbstractDecoratorManifold, Y, G::AbstractMetric, X, p)
+
+@trait_function change_representer(M::AbstractDecoratorManifold, G::AbstractMetric, X, p)
+@trait_function change_representer!(
+    M::AbstractDecoratorManifold,
+    Y,
+    G::AbstractMetric,
+    X,
+    p,
+)
+
 # Introduce Deco Trait | automatic foward | fallback
 @trait_function check_size(M::AbstractDecoratorManifold, p)
 # Embedded

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -39,3 +39,54 @@ but where the field type of the manifold is `ℂ`.
 This metric is the default metric for example for the [`Euclidean`](@ref) manifold.
 """
 struct EuclideanMetric <: RiemannianMetric end
+
+
+@doc raw"""
+    change_metric(M::AbstractcManifold, G2::AbstractMetric, p, X)
+
+On the [`AbstractManifold`](@ref) `M` with implicitly given metric ``g_1``
+and a second [`AbstractMetric`](@ref)
+``g_2`` this function performs a change of metric in the
+sense that it returns the tangent vector ``Z=BX`` such that the linear map ``B`` fulfills
+
+```math
+g_2(Y_1,Y_2) = g_1(BY_1,BY_2) \quad \text{for all } Y_1, Y_2 ∈ T_p\mathcal M.
+```
+"""
+function change_metric(M::AbstractManifold, G::AbstractMetric, p, X)
+    Y = allocate_result(M, change_metric, X, p) # this way we allocate a tangent
+    return change_metric!(M, Y, G, p, X)
+end
+
+@doc raw"""
+    change_metric!(M::AbstractcManifold, Y, G2::AbstractMetric, p, X)
+
+Compute the [`change_metric`](@ref) in place of `Y`.
+"""
+change_metric!(M::AbstractManifold, Y, G::AbstractMetric, p, X)
+
+@doc raw"""
+    change_representer(M::AbstractManifold, G2::AbstractMetric, p, X)
+
+Convert the representer `X` of a linear function (in other words a cotangent vector at `p`)
+in the tangent space at `p` on the [`AbstractManifold`](@ref) `M` given with respect to the
+[`AbstractMetric`](@ref) `G2` into the representer with respect to the (implicit) metric of `M`.
+
+In order to convert `X` into the representer with respect to the (implicitly given) metric ``g_1`` of `M`,
+we have to find the conversion function ``c: T_p\mathcal M \to T_p\mathcal M`` such that
+
+```math
+    g_2(X,Y) = g_1(c(X),Y)
+```
+"""
+function change_representer(M::AbstractManifold, G::AbstractMetric, p, X)
+    Y = allocate_result(M, change_representer, X, p) # this way we allocate a tangent
+    return change_representer!(M, Y, G, p, X)
+end
+
+@doc raw"""
+    change_representer!(M::AbstractcManifold, Y, G2::AbstractMetric, p, X)
+
+Compute the [`change_metric`](@ref) in place of `Y`.
+"""
+change_representer!(M::AbstractManifold, Y, G::AbstractMetric, p, X)

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -421,6 +421,21 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
                 @test isapprox(M, pts[1], (-1) * tv1, -tv1)
             end
 
+            @testset "Change Representer and Metric" begin
+                G = ManifoldsBase.EuclideanMetric()
+                p = pts[1]
+                for X in [tv1, tv2, tv3]
+                    @test change_representer(M, G, p, X) == X
+                    Y = similar(X)
+                    change_representer!(M, Y, G, p, X)
+                    @test isapprox(M, p, Y, X)
+                    @test change_metric(M, G, p, X) == X
+                    Z = similar(X)
+                    change_metric!(M, Z, G, p, X)
+                    @test isapprox(M, p, Z, X)
+                end
+            end
+
             @testset "Hat and vee in the tangent space" begin
                 X = log(M, pts[1], pts[2])
                 a = vee(M, pts[1], X)

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -272,9 +272,14 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
             tv2 = log(M, pts[2], pts[1])
             tv3 = log(M, pts[2], pts[3])
             @test isapprox(M, pts[2], exp(M, pts[1], tv1))
-            @test !isapprox(M, pts[1], pts[2]; error = :info)
+            @test_logs (:info,) !isapprox(M, pts[1], pts[2]; error = :info)
             @test isapprox(M, pts[1], pts[1]; error = :info)
-            @test !isapprox(M, pts[1], convert(T, [NaN, NaN, NaN]); error = :info)
+            @test_logs (:info,) !isapprox(
+                M,
+                pts[1],
+                convert(T, [NaN, NaN, NaN]);
+                error = :info,
+            )
             @test isapprox(M, pts[1], exp(M, pts[1], tv1, 0))
             @test isapprox(M, pts[2], exp(M, pts[1], tv1, 1))
             @test isapprox(M, pts[1], exp(M, pts[2], tv2))
@@ -307,7 +312,7 @@ Base.size(x::MatrixVectorTransport) = (size(x.m, 2),)
                 X_p_nan = NaN * X_p_zero
                 @test isapprox(M, p, X_p_zero, log(M, p, p); atol = eps(eltype(p)))
                 if T <: Array
-                    @test !isapprox(
+                    @test_logs (:info,) !isapprox(
                         M,
                         p,
                         X_p_zero,

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -1,5 +1,6 @@
 using Test
 using ManifoldsBase
+import ManifoldsBase: inner, change_representer, change_metric
 
 @testset "Metrics" begin
     @test ManifoldsBase.EuclideanMetric() isa ManifoldsBase.AbstractMetric

--- a/test/metric.jl
+++ b/test/metric.jl
@@ -1,6 +1,5 @@
 using Test
 using ManifoldsBase
-import ManifoldsBase: inner, change_representer, change_metric
 
 @testset "Metrics" begin
     @test ManifoldsBase.EuclideanMetric() isa ManifoldsBase.AbstractMetric

--- a/test/test_sphere.jl
+++ b/test/test_sphere.jl
@@ -79,8 +79,8 @@ end
             end
 
             @testset "isapprox" begin
-                @test !isapprox(M, p, q; error = :info)
-                @test !isapprox(M, p, X, zero_vector(M, p); error = :info)
+                @test_logs (:info,) !isapprox(M, p, q; error = :info)
+                @test_logs (:info,) !isapprox(M, p, X, zero_vector(M, p); error = :info)
             end
         end
     end


### PR DESCRIPTION
* Introduce `change_representer`already in ManifoldsBase so it can be nicely used in Manopt
* also fixes #147 removing debug output from test run.

We still might need tests for change_representer.