### PR TITLE
Make showing cached bases more robust

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.14.7"
+version = "0.14.8"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -1010,18 +1010,23 @@ function show(
     ::MIME"text/plain",
     B::CachedBasis{𝔽,T,D},
 ) where {𝔽,T<:AbstractBasis,D}
-    vectors = _get_vectors(B)
-    print(
-        io,
-        "Cached basis of type $T with $(length(vectors)) basis vector$(length(vectors) == 1 ? "" : "s"):",
-    )
-    return _show_basis_vector_range_noheader(
-        io,
-        vectors;
-        max_vectors = 4,
-        pre = "  ",
-        sym = " E",
-    )
+    try
+        vectors = _get_vectors(B)
+        print(
+            io,
+            "Cached basis of type $T with $(length(vectors)) basis vector$(length(vectors) == 1 ? "" : "s"):",
+        )
+        return _show_basis_vector_range_noheader(
+            io,
+            vectors;
+            max_vectors = 4,
+            pre = "  ",
+            sym = " E",
+        )
+    catch e
+        # in case _get_vectors(B) is not defined
+        print(io, "Cached basis of type $T")
+    end
 end
 function show(
     io::IO,

--- a/test/bases.jl
+++ b/test/bases.jl
@@ -255,6 +255,12 @@ DiagonalizingBasisProxy() = DiagonalizingOrthonormalBasis([1.0, 0.0, 0.0])
 
         M = DefaultManifold(3)
 
+        @test sprint(
+            show,
+            "text/plain",
+            CachedBasis(NonBasis(), NonBroadcastBasisThing([])),
+        ) == "Cached basis of type NonBasis"
+
         @testset "Constructors" begin
             @test DefaultBasis{ℂ,TangentSpaceType}() === DefaultBasis(ℂ)
             @test DefaultOrthogonalBasis{ℂ,TangentSpaceType}() === DefaultOrthogonalBasis(ℂ)


### PR DESCRIPTION
A tiny improvement. I've discovered this issue when working with new basis types. Having an error in printing is somewhat irritating so I think having a less informative text is still better.