### PR TITLE
Make dispatching on `TypeParameter` more flexible

### DIFF
--- a/src/maintypes.jl
+++ b/src/maintypes.jl
@@ -44,9 +44,9 @@ Represents numeric parameters of a manifold type as type parameters, allowing fo
 specialization of methods.
 """
 struct TypeParameter{T} end
-TypeParameter(t::NTuple) = TypeParameter{t}()
+TypeParameter(t::NTuple) = TypeParameter{Tuple{t...}}()
 
-get_parameter(::TypeParameter{T}) where {T} = T
+get_parameter(::TypeParameter{T}) where {T} = tuple(T.parameters...)
 get_parameter(P) = P
 
 """


### PR DESCRIPTION
Slightly reworks #160 to make it possible to dispatch on the number of type parameters and their values. E.g.
```julia
get_vector_orthonormal(::Euclidean{TypeParameter{Tuple{N}},ℝ}, ::Any, c, ::RealNumbers) where {N}
```
Sadly, I can't make this dispatching nicer.