### PR TITLE
fix tangent vector allocations (nearly)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.14.11"
+version = "0.14.12"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -854,21 +854,33 @@ Optionally a random number generator `rng` to be used can be specified. An optio
 
 """
 Random.rand(M::AbstractManifold)
+
+# unresolvable ambiguity but this would be nice to have
+#allocate_result(M::AbstractManifold, ::typeof(rand), p) = zero_vector(M, p)
+
 function Random.rand(M::AbstractManifold, d::Integer; kwargs...)
     return [rand(M; kwargs...) for _ in 1:d]
 end
 function Random.rand(rng::AbstractRNG, M::AbstractManifold, d::Integer; kwargs...)
     return [rand(rng, M; kwargs...) for _ in 1:d]
 end
-function Random.rand(M::AbstractManifold; kwargs...)
-    p = allocate_result(M, rand)
-    rand!(M, p; kwargs...)
-    return p
+function Random.rand(M::AbstractManifold; vector_at = nothing, kwargs...)
+    if vector_at === nothing
+        pX = allocate_result(M, rand)
+    else
+        pX = allocate_result(M, rand, vector_at)
+    end
+    rand!(M, pX; vector_at = vector_at, kwargs...)
+    return pX
 end
-function Random.rand(rng::AbstractRNG, M::AbstractManifold; kwargs...)
-    p = allocate_result(M, rand)
-    rand!(rng, M, p; kwargs...)
-    return p
+function Random.rand(rng::AbstractRNG, M::AbstractManifold; vector_at = nothing, kwargs...)
+    if vector_at === nothing
+        pX = allocate_result(M, rand)
+    else
+        pX = allocate_result(M, rand, vector_at)
+    end
+    rand!(rng, M, pX; vector_at = vector_at, kwargs...)
+    return pX
 end
 
 @doc raw"""

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -855,9 +855,6 @@ Optionally a random number generator `rng` to be used can be specified. An optio
 """
 Random.rand(M::AbstractManifold)
 
-# unresolvable ambiguity but this would be nice to have
-#allocate_result(M::AbstractManifold, ::typeof(rand), p) = zero_vector(M, p)
-
 function Random.rand(M::AbstractManifold, d::Integer; kwargs...)
     return [rand(M; kwargs...) for _ in 1:d]
 end


### PR DESCRIPTION
We still have one problem:

I tried to define `allocate_result(M::AbstractManifold, ::typeof(rand), p)` (commented out for now) but that is ambigous to the decorator path of allocations. The decorator path however would always pass for FixedRank to the Embedding. So we would need the specific allocation anyways?