### PR TITLE
Fix checks on TpM

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,12 @@
+name: Check Changelog
+on:
+  pull_request:
+
+jobs:
+  Check-Changelog:
+    name: Check Changelog Action
+    runs-on: ubuntu-latest
+    steps:
+      - uses: tarides/changelog-check-action@v2
+        with:
+          changelog: NEWS.md

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.0] dd/mm/2023
+## [0.15.1] 30/10/2023
+
+### Added
+
+- `zero_vector(TpM)` to generate a zero vector in the tangent space
+- a GitHub CI action that errors, when this file was not updated on a PR
+
+### Fixed
+
+- `is_point` and `is_vector` for the tangent space now correctly forward to
+  vector checks on the corresponding manifold. The same for both `check_size`s
+
+## [0.15.0] 21/10/2023
 
 ### Added
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.15.0"
+version = "0.15.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/TangentSpace.jl
+++ b/src/TangentSpace.jl
@@ -258,10 +258,19 @@ Weingarten(::TangentSpace, ::Any, ::Any, ::Any)
 Weingarten!(::TangentSpace, W, X, V, A) = fill!(W, 0)
 
 @doc raw"""
+    zero_vector(TpM::TangentSpace)
+
+Zero tangent vector in the [`TangentSpace`](@ref) `TpM`,
+that is the zero tangent vector at point `TpM.point`.
+"""
+zero_vector(TpM::TangentSpace) = zero_vector(TpM.manifold, TpM.point)
+
+@doc raw"""
     zero_vector(TpM::TangentSpace, X)
 
 Zero tangent vector at point `X` from the [`TangentSpace`](@ref) `TpM`,
-that is the zero tangent vector at point `TpM.point`.
+that is the zero tangent vector at point `TpM.point`,
+since we identify the tangent space ``T_X(T_p\mathcal M)`` with ``T_p\mathcal M``.
 """
 zero_vector(::TangentSpace, ::Any...)
 

--- a/src/TangentSpace.jl
+++ b/src/TangentSpace.jl
@@ -40,6 +40,22 @@ function allocate_result(M::TangentSpace, ::typeof(rand))
     return zero_vector(M.manifold, M.point)
 end
 
+# forward both point checks to tangent vector checks
+function check_point(TpM::TangentSpace, p; kwargs...)
+    return check_vector(TpM.manifold, TpM.point, p; kwargs...)
+end
+function check_size(TpM::TangentSpace, p; kwargs...)
+    return check_size(TpM.manifold, TpM.point, p; kwargs...)
+end
+# fix tangent vector checks to use the right base point
+function check_vector(TpM::TangentSpace, p, X; kwargs...)
+    return check_vector(TpM.manifold, TpM.point, X; kwargs...)
+end
+function check_size(TpM::TangentSpace, p, X; kwargs...)
+    return check_size(TpM.manifold, TpM.point, X; kwargs...)
+end
+
+
 """
     distance(M::TangentSpace, X, Y)
 

--- a/test/test_manifolds.jl
+++ b/test/test_manifolds.jl
@@ -1,5 +1,5 @@
 using ManifoldsBase: ℝ, ℂ, DefaultManifold, RealNumbers, EuclideanMetric
-using LinearAlgebra
+using LinearAlgebra, Random
 
 # minimal sphere implementation for testing more complicated manifolds
 struct TestSphere{N,𝔽} <: AbstractManifold{𝔽} end

--- a/test/test_sphere.jl
+++ b/test/test_sphere.jl
@@ -54,5 +54,6 @@ include("test_manifolds.jl")
         @test !is_point(TpM, p)
         @test is_vector(TpM, X, X)
         @test !is_vector(TpM, X, p)
+        @test zero_vector(TpM) == zero_vector(M, p)
     end
 end

--- a/test/test_sphere.jl
+++ b/test/test_sphere.jl
@@ -45,4 +45,14 @@ include("test_manifolds.jl")
         V = [0.1, 0.0, 0.0] #orthogonal to TpM -> parallel to p
         @test isapprox(M, p, Weingarten(M, p, X, V), -0.1 * X)
     end
+    @testset "Tangent Space" begin
+        M = TestSphere(2)
+        p = [1.0, 0.0, 0.0]
+        X = [0.0, 0.2, 0.0]
+        TpM = TangentSpace(M, p)
+        @test is_point(TpM, X)
+        @test !is_point(TpM, p)
+        @test is_vector(TpM, X, X)
+        @test !is_vector(TpM, X, p)
+    end
 end


### PR DESCRIPTION
I noticed that `is_point` and `is_vector` were a bit too vague (accepting too much as correct points/vectors).

This PR fixes that by passing points/vectors to the vector check.