### PR TITLE
Pass kwargs in rand on power manifold

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.3] 17/11/2023
+
+### Fixed
+
+- Pass kwargs in `rand!` for `AbstractPowerManifold` to appropriate methods on the wrapped manifold.
+
 ## [0.15.2] 8/11/2023
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.15.2"
+version = "0.15.3"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -1152,7 +1152,7 @@ function Random.rand!(M::AbstractPowerManifold, pX; vector_at = nothing, kwargs.
                 M.manifold,
                 _write(M, rep_size, pX, i);
                 vector_at = _read(M, rep_size, vector_at, i),
-                kwargs...
+                kwargs...,
             )
         end
     end
@@ -1177,7 +1177,7 @@ function Random.rand!(
                 M.manifold,
                 _write(M, rep_size, pX, i);
                 vector_at = _read(M, rep_size, vector_at, i),
-                kwargs...
+                kwargs...,
             )
         end
     end

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -1144,7 +1144,7 @@ function Random.rand!(M::AbstractPowerManifold, pX; vector_at = nothing, kwargs.
     rep_size = representation_size(M.manifold)
     if vector_at === nothing
         for i in get_iterator(M)
-            rand!(M.manifold, _write(M, rep_size, pX, i))
+            rand!(M.manifold, _write(M, rep_size, pX, i); kwargs...)
         end
     else
         for i in get_iterator(M)
@@ -1152,6 +1152,7 @@ function Random.rand!(M::AbstractPowerManifold, pX; vector_at = nothing, kwargs.
                 M.manifold,
                 _write(M, rep_size, pX, i);
                 vector_at = _read(M, rep_size, vector_at, i),
+                kwargs...
             )
         end
     end
@@ -1167,7 +1168,7 @@ function Random.rand!(
     rep_size = representation_size(M.manifold)
     if vector_at === nothing
         for i in get_iterator(M)
-            rand!(rng, M.manifold, _write(M, rep_size, pX, i))
+            rand!(rng, M.manifold, _write(M, rep_size, pX, i); kwargs...)
         end
     else
         for i in get_iterator(M)
@@ -1176,6 +1177,7 @@ function Random.rand!(
                 M.manifold,
                 _write(M, rep_size, pX, i);
                 vector_at = _read(M, rep_size, vector_at, i),
+                kwargs...
             )
         end
     end


### PR DESCRIPTION
We already do it for `PowerManifoldNestedReplacing`, so I've also added it to `AbstractPowerManifold`. I've noticed it while adapting tests for https://github.com/JuliaManifolds/Manifolds.jl/pull/689 .