### PR TITLE
Fix retarction with t on power manifold

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.4] 25/11/2023
+
+### Fixed
+
+* Fixed a bug reported in [Manopt#330](https://github.com/JuliaManifolds/Manopt.jl/issues/330).
+
 ## [0.15.3] 17/11/2023
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.15.3"
+version = "0.15.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -1257,6 +1257,16 @@ function retract(
     q = allocate_result(M, retract, p, X)
     return retract!(M, q, p, X, m)
 end
+function retract(
+    M::AbstractPowerManifold,
+    p,
+    X,
+    t::Number,
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
+)
+    q = allocate_result(M, retract, p, X)
+    return retract!(M, q, p, X, t, m)
+end
 
 function retract!(
     M::AbstractPowerManifold,
@@ -1287,6 +1297,28 @@ function retract!(
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
         q[i...] = retract(M.manifold, _read(M, rep_size, p, i), _read(M, rep_size, X, i), m)
+    end
+    return q
+end
+
+function retract!(
+    M::AbstractPowerManifold,
+    q,
+    p,
+    X,
+    t::Number,
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
+)
+    rep_size = representation_size(M.manifold)
+    for i in get_iterator(M)
+        retract!(
+            M.manifold,
+            _write(M, rep_size, q, i),
+            _read(M, rep_size, p, i),
+            _read(M, rep_size, X, i),
+            t,
+            m,
+        )
     end
     return q
 end

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -1257,16 +1257,6 @@ function retract(
     q = allocate_result(M, retract, p, X)
     return retract!(M, q, p, X, m)
 end
-function retract(
-    M::AbstractPowerManifold,
-    p,
-    X,
-    t::Number,
-    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
-)
-    q = allocate_result(M, retract, p, X)
-    return retract!(M, q, p, X, t, m)
-end
 
 function retract!(
     M::AbstractPowerManifold,
@@ -1300,7 +1290,6 @@ function retract!(
     end
     return q
 end
-
 function retract!(
     M::AbstractPowerManifold,
     q,

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -1290,6 +1290,7 @@ function retract!(
     end
     return q
 end
+
 function retract!(
     M::AbstractPowerManifold,
     q,
@@ -1308,6 +1309,21 @@ function retract!(
             t,
             m,
         )
+    end
+    return q
+end
+function retract!(
+    M::PowerManifoldNestedReplacing,
+    q,
+    p,
+    X,
+    t::Number,
+    m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
+)
+    rep_size = representation_size(M.manifold)
+    for i in get_iterator(M)
+        q[i...] =
+            retract(M.manifold, _read(M, rep_size, p, i), _read(M, rep_size, X, i), t, m)
     end
     return q
 end

--- a/test/power.jl
+++ b/test/power.jl
@@ -141,6 +141,10 @@ struct TestArrayRepresentation <: AbstractPowerRepresentation end
                     @test retract(N, p, q, ExponentialRetraction()) == p .+ q
                     r = allocate(p)
                     @test retract!(N, r, p, q, ExponentialRetraction()) == p .+ q
+                    @test retract(N, p, q, 1.0) == p .+ q
+                    @test retract(N, p, q, 1.0, ExponentialRetraction()) == p .+ q
+                    r = allocate(p)
+                    @test retract!(N, r, p, q, 1.0, ExponentialRetraction()) == p .+ q
                     @test r == p .+ q
                     @test inverse_retract(N, p, r) == q
                     @test inverse_retract(N, p, r, LogarithmicInverseRetraction()) == q


### PR DESCRIPTION
In our memory-allocate-first approach now for retractions and that one can use retractions directly on Power manifold (and they are defined here) we missed to pass on `retract(M, p, X, t, m)` (and its corresponding `retract!`. This resolves https://github.com/JuliaManifolds/Manopt.jl/issues/330.

I still have to check test coverage, besides that this is good to go.