### PR TITLE
Introduce AbstractEstimationMethod

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.5] 25/11/2023
+
+### Added
+
+* An `AbstractEstimationMethod` to specify estimation methods for other more general functions,
+as well as a `get_default_estimation_method` to specify defaults on manifolds.
+
 ## [0.15.4] 25/11/2023
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.15.4"
+version = "0.15.5"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,6 +2,26 @@
 #
 #
 
+if "--help" ∈ ARGS
+    println(
+        """
+docs/make.jl
+
+Render the `Manopt.jl` documenation with optinal arguments
+
+Arguments
+* `--help`              - print this help and exit without rendering the documentation
+* `--prettyurls`        – toggle the prettyurls part to true (which is otherwise only true on CI)
+* `--quarto`            – run the Quarto notebooks from the `tutorials/` folder before generating the documentation
+  this has to be run locally at least once for the `tutorials/*.md` files to exist that are included in
+  the documentation (see `--exclude-tutorials`) for the alternative.
+  If they are generated ones they are cached accordingly.
+  Then you can spare time in the rendering by not passing this argument.
+""",
+    )
+    exit(0)
+end
+
 #
 # (a) if docs is not the current active environment, switch to it
 # (from https://github.com/JuliaIO/HDF5.jl/pull/1020/) 
@@ -38,10 +58,11 @@ using ManifoldsBase
 bib = CitationBibliography(joinpath(@__DIR__, "src", "references.bib"); style = :alpha)
 makedocs(;
     # for development, we disable prettyurls
-    format = HTML(;
-        mathengine = MathJax3(),
-        prettyurls = get(ENV, "CI", nothing) == "true",
-        assets = ["assets/favicon.ico"],
+    format = Documenter.HTML(;
+        prettyurls = (get(ENV, "CI", nothing) == "true") || ("--prettyurls" ∈ ARGS),
+        assets = ["assets/favicon.ico", "assets/citations.css"],
+        size_threshold_warn = 200 * 2^10, # raise slightly from 100 to 200 KiB
+        size_threshold = 300 * 2^10,      # raise slightly 200 to to 300 KiB
     ),
     modules = [ManifoldsBase],
     authors = "Seth Axen, Mateusz Baran, Ronny Bergmann, and contributors.",

--- a/docs/src/functions.md
+++ b/docs/src/functions.md
@@ -58,6 +58,14 @@ Public=false
 Private=true
 ```
 
+## Estimation Methods
+
+```@autodocs
+Modules = [ManifoldsBase]
+Pages = ["estimation_methods.jl"]
+Order = [:type, :function]
+```
+
 ## Error Messages
 
 This interface introduces a small set of own error messages.

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -29,6 +29,7 @@ include("maintypes.jl")
 include("numbers.jl")
 include("Fiber.jl")
 include("bases.jl")
+include("estimation_methods.jl")
 include("retractions.jl")
 include("exp_log_geo.jl")
 include("projections.jl")
@@ -1015,6 +1016,17 @@ export AbstractPowerManifold, PowerManifold
 export AbstractPowerRepresentation,
     NestedPowerRepresentation, NestedReplacingPowerRepresentation
 export ProductManifold
+
+# (b) Generic Estimation Types
+
+export GeodesicInterpolationWithinRadius,
+    CyclicProximalPointEstimation,
+    ExtrinsicEstimation,
+    GradientDescentEstimation,
+    WeiszfeldEstimation,
+    AbstractEstimationMethod,
+    GeodesicInterpolation
+
 
 # (b) Retraction Types
 export AbstractRetractionMethod,

--- a/src/estimation_methods.jl
+++ b/src/estimation_methods.jl
@@ -1,0 +1,85 @@
+@doc raw"""
+    AbstractEstimationMethod
+
+Abstract type for defining estimation methods on manifolds.
+"""
+abstract type AbstractEstimationMethod end
+
+@doc raw"""
+    GradientDescentEstimation <: AbstractEstimationMethod
+
+Method for estimation using [📖 gradient descent](https://en.wikipedia.org/wiki/Gradient_descent).
+"""
+struct GradientDescentEstimation <: AbstractEstimationMethod end
+
+@doc raw"""
+    CyclicProximalPointEstimation <: AbstractEstimationMethod
+
+Method for estimation using the cyclic proximal point technique, which is based on [📖 proximal maps](https://en.wikipedia.org/wiki/Proximal_operator).
+"""
+struct CyclicProximalPointEstimation <: AbstractEstimationMethod end
+
+@doc raw"""
+    ExtrinsicEstimation{T} <: AbstractEstimationMethod
+
+Method for estimation in the ambient space with a method of type `T` and projecting the result back
+to the manifold.
+"""
+struct ExtrinsicEstimation{T} <: AbstractEstimationMethod
+    extrinsic_estimation::T
+end
+
+@doc raw"""
+    WeiszfeldEstimation <: AbstractEstimationMethod
+
+Method for estimation using the Weiszfeld algorithm, compare for example the computation of the
+[📖 Geometric median](https://en.wikipedia.org/wiki/Geometric_median).
+"""
+struct WeiszfeldEstimation <: AbstractEstimationMethod end
+
+@doc raw"""
+    GeodesicInterpolation <: AbstractEstimationMethod
+
+Method for estimation based on geodesic interpolation.
+"""
+struct GeodesicInterpolation <: AbstractEstimationMethod end
+
+@doc raw"""
+    GeodesicInterpolationWithinRadius{T} <: AbstractEstimationMethod
+
+Method for estimation based on geodesic interpolation that is restricted to some `radius`
+
+# Constructor
+
+    GeodesicInterpolationWithinRadius(radius)
+"""
+struct GeodesicInterpolationWithinRadius{T} <: AbstractEstimationMethod
+    radius::T
+
+    function GeodesicInterpolationWithinRadius(radius::T) where {T}
+        radius > 0 && return new{T}(radius)
+        return throw(
+            DomainError("The radius must be strictly postive, received $(radius)."),
+        )
+    end
+end
+
+@doc raw"""
+    default_estimation_method(M::AbstractManifold)
+    default_estimation_method(M::AbtractManifold, f, T)
+
+Specify a default estimation method for an [`AbstractManifold`](@ref) and (optional)
+for a specific function `f` and a type `T` to distinguish different (point or vector)
+representations on M.
+
+By default, all functions `f` call the signature for just a manifold.
+The exceptional functions are
+
+* `retract` and `retract!` which fall back to [`default_retraction_method`](@ref)
+* `inverse_retract` and `inverse_retract!` which fall back to [`default_inverse_retraction_method`](@ref)
+* any of the vector transport mehods fall back to [`default_vector_transport_method`](@ref)
+"""
+default_estimation_method(M::AbstractManifold)
+
+default_estimation_method(M::AbstractManifold, f, T) = get_default_estimation_method(M, f)
+default_estimation_method(M::AbstractManifold, f) = get_default_estimation_method(M)

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -1,16 +1,16 @@
 """
-    AbstractInverseRetractionMethod
+    AbstractInverseRetractionMethod <: AbstractEstimationMethod
 
 Abstract type for methods for inverting a retraction (see [`inverse_retract`](@ref)).
 """
-abstract type AbstractInverseRetractionMethod end
+abstract type AbstractInverseRetractionMethod <: AbstractEstimationMethod end
 
 """
-    AbstractRetractionMethod
+    AbstractRetractionMethod <: AbstractEstimationMethod
 
 Abstract type for methods for [`retract`](@ref)ing a tangent vector to a manifold.
 """
-abstract type AbstractRetractionMethod end
+abstract type AbstractRetractionMethod <: AbstractEstimationMethod end
 
 """
     ApproximateInverseRetraction <: AbstractInverseRetractionMethod
@@ -934,3 +934,30 @@ function retract_sasaki! end
 
 Base.show(io::IO, ::CayleyRetraction) = print(io, "CayleyRetraction()")
 Base.show(io::IO, ::PadeRetraction{m}) where {m} = print(io, "PadeRetraction($m)")
+
+#
+# default estimation methods pass down with and without the point type
+function default_estimation_method(M::AbstractManifold, ::typeof(inverse_retract))
+    return default_inverse_retraction_method(M)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(inverse_retract), T)
+    return default_inverse_retraction_method(M, T)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(inverse_retract!))
+    return default_inverse_retraction_method(M)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(inverse_retract!), T)
+    return default_inverse_retraction_method(M, T)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(retract))
+    return default_retraction_method(M)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(retract), T)
+    return default_retraction_method(M, T)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(retract!))
+    return default_retraction_method(M)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(retract!), T)
+    return default_retraction_method(M, T)
+end

--- a/src/vector_transport.jl
+++ b/src/vector_transport.jl
@@ -1,6 +1,6 @@
 
 """
-    AbstractVectorTransportMethod
+    AbstractVectorTransportMethod <: AbstractEstimationMethod
 
 Abstract type for methods for transporting vectors. Such vector transports are not
 necessarily linear.
@@ -9,7 +9,7 @@ necessarily linear.
 
 [`AbstractLinearVectorTransportMethod`](@ref)
 """
-abstract type AbstractVectorTransportMethod end
+abstract type AbstractVectorTransportMethod <: AbstractEstimationMethod end
 
 """
     AbstractLinearVectorTransportMethod <: AbstractVectorTransportMethod
@@ -309,6 +309,7 @@ end
 function default_vector_transport_method(M::AbstractManifold, ::Type{T}) where {T}
     return default_vector_transport_method(M)
 end
+
 
 @doc raw"""
     pole_ladder(
@@ -1356,4 +1357,60 @@ function _vector_transport_to!(
         ),
         m.inverse_retraction,
     )
+end
+
+# default estimation fallbacks with and without the T
+function default_estimation_method(
+    M::AbstractManifold,
+    ::typeof(vector_transport_direction),
+)
+    return default_vector_transport_method(M)
+end
+function default_estimation_method(
+    M::AbstractManifold,
+    ::typeof(vector_transport_direction!),
+)
+    return default_vector_transport_method(M)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(vector_transport_along))
+    return default_vector_transport_method(M)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(vector_transport_to))
+    return default_vector_transport_method(M)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(vector_transport_along!))
+    return default_vector_transport_method(M)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(vector_transport_to!))
+    return default_vector_transport_method(M)
+end
+function default_estimation_method(
+    M::AbstractManifold,
+    ::typeof(vector_transport_direction),
+    T,
+)
+    return default_vector_transport_method(M, T)
+end
+function default_estimation_method(
+    M::AbstractManifold,
+    ::typeof(vector_transport_direction!),
+    T,
+)
+    return default_vector_transport_method(M, T)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(vector_transport_along), T)
+    return default_vector_transport_method(M, T)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(vector_transport_to), T)
+    return default_vector_transport_method(M, T)
+end
+function default_estimation_method(
+    M::AbstractManifold,
+    ::typeof(vector_transport_along!),
+    T,
+)
+    return default_vector_transport_method(M, T)
+end
+function default_estimation_method(M::AbstractManifold, ::typeof(vector_transport_to!), T)
+    return default_vector_transport_method(M, T)
 end


### PR DESCRIPTION
This PR tackles a discussion from https://github.com/JuliaManifolds/Manifolds.jl/issues/661 and introduces the `AbstractEstimationMethod` already here in ManifoldsBase.jl

There are two changes I modelled here as well while rethinking this concept a bit

* The `ExtrinsicEstimation` now stores another method internally which method to use in the embedding. We could maybe even rename it to EmbeddedEstimation
* the retraction, inverse retraction and vector transport method types are now subtypes of this type, since all of them are estimates (of eco, log and parallel transport, resp.)
* there is a new `default_estimation_method` with 3 parameters: a manifold, a function and a type. The function is to distinguish (possibly) different methods for every function – the T similar to the three methods above to distinguish different point representations. 

The new method `default_estimation_method` falls back to the existing  default methods like `default_retraction_method` when providing `retract` or `retract!` as a function.

If this design is fine (feedback wanted :) ), I can implement the necessary tests (though that is a bit of work I think).

With this available, the mean/median in in manifolds might become nicer, but especially in Manopt one can specify the mean method more fine granular, eg. in Nelder-Mead.

# ToDo
* [x] introduce estimation methods already in ManifoldsBase.jl and make it a super type of existing methods
* [x] add their doc strings to the documentation
* [x] introduce a new `default_estifmation_method(M[, f, T)`
* [x] introduce fallbacks of the method from the last point for existing default functions
* [ ] Test coverage.
