### PR TITLE
Fix info/warn print of checks

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.6] unreleased
+## [0.15.7] 24/01/2024
+
+### Fixed
+
+* `is_point` and `is_vector` can now more stably `:info` or `:warn` when they return false,
+  since they emply `showerror` for these displays.
+
+## [0.15.6] 15/12/2023
 
 ### Added
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.15.6"
+version = "0.15.7"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/docs/src/projections.md
+++ b/docs/src/projections.md
@@ -14,18 +14,18 @@ the embedding can be chosen to be the manifold ``\mathcal N = ℂ`` and due to o
 The first projection we can consider is for a given a point ``p∈\mathcal N`` in the embedding we can look for the closest point on the manifold ``\mathcal M``, i.e.
 
 ```math
-  \operatorname*{arg\,min}_{q\in \mathcal M}\ d_{\mathcal N}(i(q),p)
+  \operatorname*{arg\,min}_{q∈ \mathcal M}\ d_{\mathcal N}(i(q),p)
 ```
 
 And this resulting ``q`` we call the projection of ``p`` onto the manifold ``\mathcal M``.
 
-The second projection we can look at is for a given a point ``p∈\mathcal M`` and a vector in ``X\in T_{i(p)}\mathcal N`` in the embedding,
+The second projection we can look at is for a given a point ``p∈\mathcal M`` and a vector in ``X∈ T_{i(p)}\mathcal N`` in the embedding,
 where we can similarly look for the closest tangent vector ``Y∈ T_p\mathcal M``, which we have to embed itself before itself.
 Embedding a tangent vector is usually the same as using the pushforward ``\mathrm{d}i_p`` of the embedding (at ``p``).
 We obtain
 
 ```math
-  \operatorname*{arg\,min}_{Y\in T_p\mathcal M}\ \bigl\lVert \mathrm{d}i(p)[Y] - X \bigr\rVert_{i(p)}
+  \operatorname*{arg\,min}_{Y∈ T_p\mathcal M}\ \bigl\lVert \mathrm{d}i(p)[Y] - X \bigr\rVert_{i(p)}
 ```
 
 And we call the resulting ``Y`` the projection of ``X`` onto the tangent space ``T_p\mathcal M`` at ``p``.

--- a/docs/src/retractions.md
+++ b/docs/src/retractions.md
@@ -3,11 +3,11 @@
 The [exponential and logarithmic map](@ref exp-and-log) might be too expensive to evaluate or not be available in a very stable numerical way on certain manifolds ``\mathcal M``.
 Retractions provide a possibly cheap, fast and stable alternative.
 
-A _retraction_ ``\operatorname{retr}_p: T_p\mathcal M → \mathcal M`` is a smooth map that fulfils (for all ``p\in\mathcal M``) that
+A _retraction_ ``\operatorname{retr}_p: T_p\mathcal M → \mathcal M`` is a smooth map that fulfils (for all ``p∈\mathcal M``) that
 
 1. ``\operatorname{retr}_p(0) = p``
 2. ``D\operatorname{retr}_p(0): T_p\mathcal M \to T_p\mathcal M`` is the identity map,
-i.e. ``D\operatorname{retr}_p(0)[X]=X`` holds for all ``X\in T_p\mathcal M``,
+i.e. ``D\operatorname{retr}_p(0)[X]=X`` holds for all ``X∈ T_p\mathcal M``,
 
 where ``D\operatorname{retr}_p`` denotes the differential of the retraction.
 

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -567,11 +567,10 @@ function isapprox(M::AbstractManifold, p, q; error::Symbol = :none, kwargs...)
         ma = check_approx(M, p, q; kwargs...)
         if ma !== nothing
             (error === :error) && throw(ma)
-            if isnan(ma.val)
-                s = "$(typeof(ma))\n$(ma.msg)"
-            else
-                s = "$(typeof(ma)) with $(ma.val)\n$(ma.msg)"
-            end
+            # else: collect and info showerror
+            io = IOBuffer()
+            showerror(io, ma)
+            s = String(take!(io))
             (error === :info) && @info s
             (error === :warn) && @warn s
             return false
@@ -607,11 +606,10 @@ function isapprox(M::AbstractManifold, p, X, Y; error::Symbol = :none, kwargs...
         mat = check_approx(M, p, X, Y; kwargs...)
         if mat !== nothing
             (error === :error) && throw(mat)
-            if isnan(mat.val)
-                s = "$(typeof(mat))\n$(mat.msg)"
-            else
-                s = "$(typeof(mat)) with $(mat.val)\n$(mat.msg)"
-            end
+            # else: collect and info showerror
+            io = IOBuffer()
+            showerror(io, mat)
+            s = String(take!(io))
             (error === :info) && @info s
             (error === :warn) && @warn s
             return false
@@ -678,7 +676,10 @@ function is_point(M::AbstractManifold, p; error::Symbol = :none, kwargs...)
     if mps !== nothing
         (error === :error) && throw(mps)
         if (error === :info) || (error === :warn)
-            s = "$(typeof(mps)) with $(mps.val)\n$(mps.msg)"
+            # else: collect and info showerror
+            io = IOBuffer()
+            showerror(io, mps)
+            s = String(take!(io))
             (error === :info) && @info s
             (error === :warn) && @warn s
         end
@@ -688,7 +689,10 @@ function is_point(M::AbstractManifold, p; error::Symbol = :none, kwargs...)
     if mpe !== nothing
         (error === :error) && throw(mpe)
         if (error === :info) || (error === :warn)
-            s = "$(typeof(mpe)) with $(mpe.val)\n$(mpe.msg)"
+            # else: collect and info showerror
+            io = IOBuffer()
+            showerror(io, mpe)
+            s = String(take!(io))
             (error === :info) && @info s
             (error === :warn) && @warn s
         end
@@ -756,7 +760,10 @@ function is_vector(
     if mXs !== nothing
         (error === :error) && throw(mXs)
         if (error === :info) || (error === :warn)
-            s = "$(typeof(mXs)) with $(mXs.val)\n$(mXs.msg)"
+            # else: collect and info showerror
+            io = IOBuffer()
+            showerror(io, mXs)
+            s = String(take!(io))
             (error === :info) && @info s
             (error === :warn) && @warn s
         end
@@ -766,7 +773,10 @@ function is_vector(
     if mXe !== nothing
         (error === :error) && throw(mXe)
         if (error === :info) || (error === :warn)
-            s = "$(typeof(mXe)) with $(mXe.val)\n$(mXe.msg)"
+            # else: collect and info showerror
+            io = IOBuffer()
+            showerror(io, mXe)
+            s = String(take!(io))
             (error === :info) && @info s
             (error === :warn) && @warn s
         end

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -959,7 +959,7 @@ size of the power manifold and ``d_{\mathcal M}`` the dimension of the base mani
 ``\mathcal M``, the manifold is of dimension
 
 ````math
-\dim(\mathcal N) = \dim(\mathcal M)\prod_{i=1}^d n_i = n_1n_2\cdot…\cdot n_d \dim(\mathcal M).
+\dim(\mathcal N) = \dim(\mathcal M)\prod_{i=1}^d n_i = n_1n_2⋅…⋅ n_d \dim(\mathcal M).
 ````
 """
 function manifold_dimension(M::PowerManifold)

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -412,7 +412,10 @@ function is_point(
     mpe = check_point(M, p; kwargs...)
     if mpe !== nothing
         (error === :error) && throw(mpe)
-        s = "$(typeof(mpe)) with $(mpe.val)\n$(mpe.msg)"
+        # else: collect and info showerror
+        io = IOBuffer()
+        showerror(io, mpe)
+        s = String(take!(io))
         (error === :info) && @info s
         (error === :warn) && @warn s
         return false
@@ -436,7 +439,10 @@ function is_vector(
     es = check_size(M, p, X)
     if es !== nothing
         (error === :error) && throw(es)
-        s = "$(typeof(es)) with $(es)"
+        # else: collect and info showerror
+        io = IOBuffer()
+        showerror(io, es)
+        s = String(take!(io))
         (error === :info) && @info s
         (error === :warn) && @warn s
         return false
@@ -478,7 +484,10 @@ function is_vector(
     mXe = check_vector(M, p, X; kwargs...)
     mXe === nothing && return true
     (error === :error) && throw(mXe)
-    s = "$(typeof(mXe)) with $(mXe.val)\n$(mXe.msg)"
+    # else: collect and info showerror
+    io = IOBuffer()
+    showerror(io, mXe)
+    s = String(take!(io))
     (error === :info) && @info s
     (error === :warn) && @warn s
     return false

--- a/test/domain_errors.jl
+++ b/test/domain_errors.jl
@@ -37,14 +37,14 @@ end
     @test !is_point(M, [1, 1, 1]) # checksize fails
     @test_throws DomainError is_point(M, [-1, 1, 1], true) # checksize errors
     @test_throws DomainError is_point(M, [-1, 1, 1]; error = :error) # checksize errors
-    cs = "DomainError with (3,)\nsize [-1, 1, 1] not (2,)"
+    cs = "DomainError with (3,):\nsize [-1, 1, 1] not (2,)"
     @test_logs (:info, cs) is_point(M, [-1, 1, 1]; error = :info)
     @test_logs (:warn, cs) is_point(M, [-1, 1, 1]; error = :warn)
     @test is_point(M, [1, 1])
     @test is_point(M, [1, 1]; error = :error)
     @test_throws DomainError is_point(M, [-1, 1], true)
     @test_throws DomainError is_point(M, [-1, 1]; error = :error)
-    ps = "DomainError with [-1, 1]\n<0"
+    ps = "DomainError with [-1, 1]:\n<0"
     @test_logs (:info, ps) is_point(M, [-1, 1]; error = :info)
     @test_logs (:warn, ps) is_point(M, [-1, 1]; error = :warn)
 
@@ -54,20 +54,20 @@ end
     @test !is_vector(M, [1, 1], [1, 1, 1])
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1, 1], false, true)
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1, 1]; error = :error)
-    vs = "DomainError with (3,)\nsize [-1, 1, 1] not (2,)"
+    vs = "DomainError with (3,):\nsize [-1, 1, 1] not (2,)"
     @test_logs (:info, vs) is_vector(M, [1, 1], [-1, 1, 1]; error = :info)
     @test_logs (:warn, vs) is_vector(M, [1, 1], [-1, 1, 1]; error = :warn)
     @test !is_vector(M, [1, 1, 1], [1, 1, 1], false)
     @test_throws DomainError is_vector(M, [1, 1, 1], [1, 1], true, true)
     @test_throws DomainError is_vector(M, [1, 1, 1], [1, 1], true; error = :error)
-    ps2 = "DomainError with (3,)\nsize [1, 1, 1] not (2,)"
+    ps2 = "DomainError with (3,):\nsize [1, 1, 1] not (2,)"
     @test_logs (:info, ps2) is_vector(M, [1, 1, 1], [1, 1], true; error = :info)
     @test_logs (:warn, ps2) is_vector(M, [1, 1, 1], [1, 1], true; error = :warn)
     @test is_vector(M, [1, 1], [1, 1])
     @test is_vector(M, [1, 1], [1, 1]; error = :none)
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1]; error = :error)
     @test_throws DomainError is_vector(M, [1, 1], [-1, 1], true; error = :error)
-    ps3 = "DomainError with [-1, 1]\n<0"
+    ps3 = "DomainError with [-1, 1]:\n<0"
     @test_logs (:info, ps3) is_vector(M, [1, 1], [-1, 1], true; error = :info)
     @test_logs (:warn, ps3) is_vector(M, [1, 1], [-1, 1], true; error = :warn)
 end


### PR DESCRIPTION
As we noticed in [Manifolds.jl/#702](https://github.com/JuliaManifolds/Manifolds.jl/pull/702) sometimes errors printed on info/warn  errored themselves

This was due to a “hardcoded” print using `e.val` and `e.msg` which not all errors might have.

This PR fixes that by using `showerror` instead, which errors should implement anyways.