### PR TITLE
Improved performance of power manifold creation and more

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.12] unreleased
+
+### Changed
+
+* Improved performance of power manifold creation and some cases of `get_component` on product manifold.
+
 ## [0.15.11] 28/07/2024
 
 ### Added

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.15.12] unreleased
+## [0.15.12] 03/08/2024
 
 ### Changed
 

--- a/ext/ManifoldsBaseRecursiveArrayToolsExt/ProductManifoldRecursiveArrayToolsExt.jl
+++ b/ext/ManifoldsBaseRecursiveArrayToolsExt/ProductManifoldRecursiveArrayToolsExt.jl
@@ -148,7 +148,7 @@ Access the element(s) at index `i` of a point `p` on a [`ProductManifold`](@ref)
 linear indexing.
 See also [Array Indexing](https://docs.julialang.org/en/v1/manual/arrays/#man-array-indexing-1) in Julia.
 """
-Base.@propagate_inbounds function Base.getindex(
+@inline Base.@propagate_inbounds function Base.getindex(
     p::ArrayPartition,
     M::ProductManifold,
     i::Union{Integer,Colon,AbstractVector,Val},

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -38,6 +38,16 @@ include("exp_log_geo.jl")
 include("projections.jl")
 include("metric.jl")
 
+if isdefined(Base, Symbol("@constprop"))
+    macro aggressive_constprop(ex)
+        return esc(:(Base.@constprop :aggressive $ex))
+    end
+else
+    macro aggressive_constprop(ex)
+        return esc(ex)
+    end
+end
+
 """
     allocate(a)
     allocate(a, dims::Integer...)

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -100,7 +100,7 @@ function _parameter_symbol(
     return :type
 end
 
-Base.@constprop :aggressive function PowerManifold(
+@aggressive_constprop function PowerManifold(
     M::AbstractManifold{𝔽},
     ::TPR,
     size::Integer...;
@@ -109,7 +109,7 @@ Base.@constprop :aggressive function PowerManifold(
     size_w = wrap_type_parameter(parameter, size)
     return PowerManifold{𝔽,typeof(M),typeof(size_w),TPR}(M, size_w)
 end
-Base.@constprop :aggressive function PowerManifold(
+@aggressive_constprop function PowerManifold(
     M::PowerManifold{𝔽,TM,TSize,TPR},
     size::Integer...;
     parameter::Symbol = _parameter_symbol(M),
@@ -117,7 +117,7 @@ Base.@constprop :aggressive function PowerManifold(
     size_w = wrap_type_parameter(parameter, (get_parameter(M.size)..., size...))
     return PowerManifold{𝔽,TM,typeof(size_w),TPR}(M.manifold, size_w)
 end
-Base.@constprop :aggressive function PowerManifold(
+@aggressive_constprop function PowerManifold(
     M::PowerManifold{𝔽,TM},
     ::TPR,
     size::Integer...;

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -100,7 +100,7 @@ function _parameter_symbol(
     return :type
 end
 
-function PowerManifold(
+Base.@constprop :aggressive function PowerManifold(
     M::AbstractManifold{𝔽},
     ::TPR,
     size::Integer...;
@@ -109,7 +109,7 @@ function PowerManifold(
     size_w = wrap_type_parameter(parameter, size)
     return PowerManifold{𝔽,typeof(M),typeof(size_w),TPR}(M, size_w)
 end
-function PowerManifold(
+Base.@constprop :aggressive function PowerManifold(
     M::PowerManifold{𝔽,TM,TSize,TPR},
     size::Integer...;
     parameter::Symbol = _parameter_symbol(M),
@@ -117,7 +117,7 @@ function PowerManifold(
     size_w = wrap_type_parameter(parameter, (get_parameter(M.size)..., size...))
     return PowerManifold{𝔽,TM,typeof(size_w),TPR}(M.manifold, size_w)
 end
-function PowerManifold(
+Base.@constprop :aggressive function PowerManifold(
     M::PowerManifold{𝔽,TM},
     ::TPR,
     size::Integer...;

--- a/src/ProductManifold.jl
+++ b/src/ProductManifold.jl
@@ -445,7 +445,7 @@ end
 
 Get the `i`th component of a point `p` on a [`ProductManifold`](@ref) `M`.
 """
-function get_component(M::ProductManifold, p, i)
+@inline function get_component(M::ProductManifold, p, i)
     return submanifold_component(M, p, i)
 end
 


### PR DESCRIPTION
The ManifoldsBase.jl improvements that are needed for better performance of IPM.

Note: constraints are creating new PowerManifolds at every access and these constructors were type-unstable before these changes, creating significant slowdowns.

`get_component(M::ProductManifold, p, i)` with integers is still slow and I didn't really want to sprinkle everything with `Base.@constprop :aggressive ` to try to improve it.