### PR TITLE
Refactored error message when no RAT.jl

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.15.15] 29/08/2024
+
+### Changed
+
+* Refactored error message code when `ProductManifold` is used without `RecursiveArrayTools.jl`.
+
 ## [0.15.14] 27/08/2024
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "0.15.14"
+version = "0.15.15"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -180,15 +180,18 @@ end
 @inline function allocate_result(M::AbstractManifold, f)
     T = allocate_result_type(M, f, ())
     rs = representation_size(M)
-    if isnothing(rs)
-        msg = "Could not allocate result of function $f on manifold $M."
-        if M isa ProductManifold
-            msg *= " This error could be resolved by importing RecursiveArrayTools.jl. If this is not the case, please open report an issue."
-        end
-        error(msg)
-    else
-        return Array{T}(undef, rs...)
+    return allocate_result_array(M, f, T, rs)
+end
+
+function allocate_result_array(M::AbstractManifold, f, ::Type, ::Nothing)
+    msg = "Could not allocate result of function $f on manifold $M."
+    if base_manifold(M) isa ProductManifold
+        msg *= " This error could be resolved by importing RecursiveArrayTools.jl. If this is not the case, please open report an issue."
     end
+    return error(msg)
+end
+function allocate_result_array(::AbstractManifold, f, T::Type, rs::Tuple)
+    return Array{T}(undef, rs...)
 end
 
 """


### PR DESCRIPTION
A small improvement to #201 to make it easier to handle another similar issue in Manifolds.jl, regarding `identity_element`.