### PR TITLE
Adapt Tutorial to ManifoldsBase 1.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `parallel_transport_along(M, p, X, c)`, `vector_transport_along(M, p, X, c, m)` as well as
   their mutating variants are removed from the API for now.
   It was never specified how to actually specify a curve `c` and the method was only
-  implemented for `Euclidean` in `Manifolds.jl` anyways.
+  implemented for `Euclidean` in `Manifolds.jl`, where it is the identity.
 
 ## [0.15.24] 17/01/2025
 

--- a/tutorials/implement-a-manifold.qmd
+++ b/tutorials/implement-a-manifold.qmd
@@ -251,9 +251,8 @@ Here, we really have to take into account, that the interface is ``[designed wit
 While the actual function we would call in the end is `retract(M, p, X, ProjectionRetraction())` (or its `!` variant), we actually have to implement `retract_project!(M, q, p, X, t)` for technical details, that are a bit beyond this introductory tutorial. In short this split avoids ambiguity errors for decorators of the manifolds. We define
 
 ```{julia}
-import ManifoldsBase: retract_project_fused!
-function retract_project_fused!(M::ScaledSphere, q, p, X, t::Number)
-    q .= (p + t*X) .* (M.radius/norm(p + t*X))
+function ManifoldsBase.retract_project!(M::ScaledSphere, q, p, X)
+    q .= (p + X) .* (M.radius/norm(p + X))
     return q
 end
 ```


### PR DESCRIPTION
We forgot to clear the cache so the new tutorial was never rendered. It mixed retract and the fused variant. Since it is an intro tutorial, this was simplified to just using retract.