### PR TITLE
Allow an `allocate(M, f, T)` case

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "1.0.1"
+version = "1.1.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -163,10 +163,19 @@ function _pick_basic_allocation_argument(::AbstractManifold, f, x...)
 end
 
 """
+    allocate_result(M::AbstractManifold, f)
     allocate_result(M::AbstractManifold, f, x...)
+    allocate_result(M::AbstractManifold, f, T::Type)
 
 Allocate an array for the result of function `f` on [`AbstractManifold`](@ref) `M` and arguments
 `x...` for implementing the non-modifying operation using the modifying operation.
+
+Internally one of the arguments of `x...` is used to determine the dimensions of the result.
+
+If no arguments are present, for example for a function that has no (point/vector) arguments,
+a default type is determined with [`allocate_result_type`](@ref) `T`.
+If either that type or another type (maybe a non-default representation) is provided,
+an array of size [`representation_size`](@ref) is allocated using [`allocate_result_array`](@ref)
 
 Usefulness of passing a function is demonstrated by methods that allocate results of musical
 isomorphisms.
@@ -178,6 +187,9 @@ isomorphisms.
 end
 @inline function allocate_result(M::AbstractManifold, f)
     T = allocate_result_type(M, f, ())
+    return allocate_result(M::AbstractManifold, f, T)
+end
+@inline function allocate_result(M::AbstractManifold, f, T::Type)
     rs = representation_size(M)
     return allocate_result_array(M, f, T, rs)
 end

--- a/src/ValidationManifold.jl
+++ b/src/ValidationManifold.jl
@@ -244,7 +244,7 @@ end
 
 
 """
-    _msg(str; error=:None, within::Union{Nothing,<:Function} = nothing,
+    _msg(M::ValidationManifold, str; error=:None, within::Union{Nothing,<:Function} = nothing,
     context::Union{NTuple{N,Symbol} where N} = NTuple{0,Symbol}())
 
 issue a message `str` according to the mode `mode` (as `@error`, `@warn`, `@info`).

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -95,6 +95,13 @@ get_embedding(M::AbstractDecoratorManifold, p) = get_embedding(M)
 ) where {TF,N}
     return allocate_result(trait(allocate_result, M, f, x...), M, f, x...)
 end
+@inline function allocate_result(
+    M::AbstractDecoratorManifold,
+    f::TF,
+    T::Type,
+) where {TF}
+    return allocate_result(trait(allocate_result, M, f, T), M, f, T)
+end
 # disambiguation
 @invoke_maker 1 AbstractManifold allocate_result(
     M::AbstractDecoratorManifold,


### PR DESCRIPTION
This was an interims step anyways when calling `allocate_result(M; f)` but I would like to have it as an extra step especially for functions like `zero_vector(G, T)` where we do not have a `x` variable to “allocate from” but also do not want to use the “default type” `allocate_result_type` would return.

The idea _should_ work, I just got a bit lost in fighting ambiguities for now