### PR TITLE
fix a typo that caused a few docs to render wrongly.

### DIFF
--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -16,7 +16,7 @@ jobs:
           version: "1.5.55"
       - uses: julia-actions/setup-julia@latest
         with:
-          version: "1.11"
+          version: "1.12"
       - name: Julia Cache
         uses: julia-actions/cache@v2
       - name: Cache Quarto

--- a/.github/workflows/documenter.yml
+++ b/.github/workflows/documenter.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: quarto-dev/quarto-actions/setup@v2
         with:
-          version: "1.5.55"
+          version: "1.7.29"
       - uses: julia-actions/setup-julia@latest
         with:
           version: "1.12"

--- a/docs/CondaPkg.toml
+++ b/docs/CondaPkg.toml
@@ -1,3 +1,0 @@
-[deps]
-jupyter = ""
-python = "3.11"

--- a/src/quotientmanifold.jl
+++ b/src/quotientmanifold.jl
@@ -23,7 +23,7 @@ function canonical_project! end
 @doc "$(_doc_canonical_project)"
 canonical_project!(M::AbstractManifold, q, p)
 
-_doc_diff_canonical_project = @doc raw"""
+_doc_diff_canonical_project = raw"""
     diff_canonical_project(M::AbstractManifold, p, X)
     diff_canonical_project!(M::AbstractManifold, Y, p, X)
 

--- a/tutorials/.gitignore
+++ b/tutorials/.gitignore
@@ -1,1 +1,3 @@
 /.quarto/
+
+**/*.quarto_ipynb

--- a/tutorials/Project.toml
+++ b/tutorials/Project.toml
@@ -1,9 +1,7 @@
 [deps]
-IJulia = "7073ff75-c697-5162-941a-fcdaad2a7d2a"
 ManifoldsBase = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [compat]
-IJulia = "1"
 ManifoldsBase = "1,2"
 Plots = "1.38"


### PR DESCRIPTION
just a small typo that a macro took over one step too early, when defining the string.