### PR TITLE
Faster get_vector! on power manifolds

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] 25/02/2026
+
+### Changed
+
+* `get_vector!` on `AbstractPowerManifold` now works faster by constructing views of the vector of coordinates instead of slicing it.
+
+
 ## [2.3.1] 14/02/2026
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "2.3.1"
+version = "2.3.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -798,7 +798,8 @@ function get_vector!(
     v_iter = 1
     for i in get_iterator(M)
         get_vector!(
-            M.manifold, _write(M, rep_size, Y, i), _read(M, rep_size, p, i), c[v_iter:(v_iter + dim - 1)], _access_nested(M, B.data.bases, i),
+            M.manifold, _write(M, rep_size, Y, i), _read(M, rep_size, p, i),
+            view(c, v_iter:(v_iter + dim - 1)), _access_nested(M, B.data.bases, i),
         )
         v_iter += dim
     end
@@ -812,7 +813,8 @@ function get_vector!(
     v_iter = 1
     for i in get_iterator(M)
         Y[i...] = get_vector(
-            M.manifold, _read(M, rep_size, p, i), c[v_iter:(v_iter + dim - 1)], _access_nested(M, B.data.bases, i),
+            M.manifold, _read(M, rep_size, p, i), view(c, v_iter:(v_iter + dim - 1)),
+            _access_nested(M, B.data.bases, i),
         )
         v_iter += dim
     end
@@ -828,7 +830,8 @@ function get_vector!(M::AbstractPowerManifold, Y, p, c, B::AbstractBasis)
     v_iter = 1
     for i in get_iterator(M)
         get_vector!(
-            M.manifold, _write(M, rep_size, Y, i), _read(M, rep_size, p, i), c[v_iter:(v_iter + dim - 1)], B,
+            M.manifold, _write(M, rep_size, Y, i), _read(M, rep_size, p, i),
+            view(c, v_iter:(v_iter + dim - 1)), B,
         )
         v_iter += dim
     end
@@ -840,7 +843,7 @@ function get_vector!(M::PowerManifoldNestedReplacing, Y, p, c, B::AbstractBasis)
     v_iter = 1
     for i in get_iterator(M)
         Y[i...] = get_vector(
-            M.manifold, _read(M, rep_size, p, i), c[v_iter:(v_iter + dim - 1)], B,
+            M.manifold, _read(M, rep_size, p, i), view(c, v_iter:(v_iter + dim - 1)), B,
         )
         v_iter += dim
     end


### PR DESCRIPTION
I'm surprised I haven't encountered this issue sooner.