### PR TITLE
Faster `submanifold_component` on `ArrayPartition` with integer index

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.4] 25/03/2026
+
+### Changed
+
+* `submanifold_component` with an integer index on `ArrayPartition` now skips creating `Val` objects and directly accesses the component. This is a more efficient way to access components of an `ArrayPartition`.
+
 ## [2.3.3] 21/03/2026
 
 ### Fixed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
-version = "2.3.3"
+version = "2.3.4"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/ext/ManifoldsBaseRecursiveArrayToolsExt/ProductManifoldRecursiveArrayToolsExt.jl
+++ b/ext/ManifoldsBaseRecursiveArrayToolsExt/ProductManifoldRecursiveArrayToolsExt.jl
@@ -330,6 +330,8 @@ Base.@propagate_inbounds function Base.setindex!(
 end
 
 @inline submanifold_component(p::ArrayPartition, ::Val{I}) where {I} = p.x[I]
+@inline submanifold_component(::ProductManifold, p::ArrayPartition, i::Integer) = p.x[i]
+@inline submanifold_component(p::ArrayPartition, i::Integer) = p.x[i]
 @inline submanifold_components(p::ArrayPartition) = p.x
 
 function vector_transport_direction(

--- a/test/product_manifold.jl
+++ b/test/product_manifold.jl
@@ -505,8 +505,11 @@ using RecursiveArrayTools
 
     @testset "ArrayPartition" begin
         @test submanifold_component(M, p1, 1) === p1.x[1]
+        # @invoke to test that the generic fallback is used, which should behave the same as the specialized version
+        @test (@invoke submanifold_component(M, p1::Any, 1)) === p1.x[1]
         @test submanifold_component(M, p1, Val(1)) === p1.x[1]
         @test submanifold_component(p1, 1) === p1.x[1]
+        @test (@invoke submanifold_component(p1::Any, 1)) === p1.x[1]
         @test submanifold_component(p1, Val(1)) === p1.x[1]
         @test submanifold_components(M, p1) === p1.x
         @test submanifold_components(p1) === p1.x


### PR DESCRIPTION
It's really hard to go the Val-route in the GCD code, so let's make the Integer-route less punishing.