### PR TITLE
Fix injectivity_radius documentation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.6] 25/05/2026
+## [2.3.6] unreleased
 
 ### Fixed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.6] 25/05/2026
+
+### Fixed
+
+* documentation of the `injectivity_radius` function now displays clearer instructions for the implementation of a radius linked to a user's own `AbstractRetractionMethod`.
+
 ## [2.3.5] 03/04/2026
 
 ### Changed

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* (#270) documentation of the `injectivity_radius` function now displays clearer instructions for the implementation of a radius linked to a user's own `AbstractRetractionMethod`.
+* (documentation of the `injectivity_radius` function now displays clearer instructions for the implementation of a radius linked to a user's own `AbstractRetractionMethod`. [#270](https://github.com/JuliaManifolds/ManifoldsBase.jl/pull/270))
 
 ## [2.3.5] 03/04/2026
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* (documentation of the `injectivity_radius` function now displays clearer instructions for the implementation of a radius linked to a user's own `AbstractRetractionMethod`. [#270](https://github.com/JuliaManifolds/ManifoldsBase.jl/pull/270))
+* (documentation of the `injectivity_radius` function now displays clearer instructions for the implementation of a radius linked to a user's own `AbstractRetractionMethod`. (#270)
 
 ## [2.3.5] 03/04/2026
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-* documentation of the `injectivity_radius` function now displays clearer instructions for the implementation of a radius linked to a user's own `AbstractRetractionMethod`.
+* (#270) documentation of the `injectivity_radius` function now displays clearer instructions for the implementation of a radius linked to a user's own `AbstractRetractionMethod`.
 
 ## [2.3.5] 03/04/2026
 

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -674,8 +674,8 @@ is injective for all tangent vectors shorter than ``d`` (i.e. has an inverse) fo
 if provided or all manifold points otherwise.
 
 In order to dispatch on different retraction methods, please either implement
-`_injectivity_radius(M[, p], m::T)` for your retraction `R` or specifically `injectivity_radius_exp(M[, p])` for the exponential map.
-By default the variant with a point `p` assumes that the default (without `p`) can ve called as a lower bound.
+`_injectivity_radius(M[, p], m::T)` for your retraction `m` or specifically `injectivity_radius_exp(M[, p])` for the exponential map.
+By default the variant with a point `p` assumes that the default (without `p`) can be called as a lower bound.
 """
 injectivity_radius(M::AbstractManifold)
 injectivity_radius(M::AbstractManifold, p) = injectivity_radius(M)


### PR DESCRIPTION
The former version used the letter `R` that was not involved in the call `_injectivity_radius(M[, p], m::T)`.

As I understand, `m` is the `AbstractRetractionMethod` for which the injectivity radius is expected to be implemented.