### PR TITLE
A(n AI assisted/annoyed) Code review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ tutorials/_freeze
 docs/.CondaPkg
 docs/src/NEWS.md
 temp
+test/LocalPreferences.toml

--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * [DocumenterCodeBlocks.jl](https://fredrikekre.github.io/DocumenterCodeBlocks.jl/stable/) plugin added to the documentation
 * [DocumenterLandingPage.jl](https://csvance.github.io/DocumenterLandingPage.jl/) enhances the start page with a short teaser for the package now.
 
+### Fixed
+
+* `get_coordinates`/`get_vector` with a `DefaultOrthogonalBasis` now allocate and call their mutating orthogonal variant instead of forwarding to the orthonormal one; the orthogonal-to-orthonormal fallback now only happens in `get_coordinates_orthogonal!`/`get_vector_orthogonal!`.
+* `angle` clamps the `acos` argument to `[-1, 1]`, which rounding could exceed for nearly parallel vectors.
+* `project!` on a `PowerManifoldNestedReplacing` writes to the result instead of the point.
+* `sectional_curvature_min` on a power manifold uses the minimum, not the maximum, of the wrapped manifold.
+* `parallel_transport_to!` on a power manifold calls `parallel_transport_to!` on the base manifold elementwise, instead of its default vector transport.
+* `injectivity_radius(M::AbstractPowerManifold, m)` forwards `m` to the wrapped manifold.
+* `sectional_curvature` on a `ProductManifold` weights each factor by its Gram determinant and normalizes by that of the product; it summed them unweighted before.
+* `NLSolveInverseRetraction` stores `project_point` and `project_tangent` in their own fields.
+* `retract_embedded!`, `retract_embedded_fused!` and `inverse_retract_embedded!` embed with `embed(M, ...)`, not `embed(get_embedding(M), ...)`.
+* `allocate_result_embedding` looks up the embedding by point type, not tangent vector type.
+* `get_coordinates` on a `ValidationManifold` unwraps its point and tangent vector.
+* `rand(::ValidationManifold; vector_at=)` unwraps `vector_at`.
+* `zero_vector!` on a `ValidationManifold` no longer forwards validation keywords to the wrapped manifold.
+* `vector_transport_direction_embedded!` embeds the direction as a tangent vector.
+* the allocating `vector_transport_to` wraps keywords in `VectorTransportWithKeywords` instead of forwarding them to the keyword-less `vector_transport_to!`.
+* `is_default_connection(M::ConnectionManifold)` compares `connection(M.manifold)` with `M.connection` instead of returning `true`.
+* `@default_manifold_fallbacks` generates the `diff` and `embedded` vector transport forwardings with their method argument.
+* `check_vector` of `ManifoldsBase.Test.TestSphere` takes an `atol`, defaulting to `sqrt(prod(representation_size(M))) * eps`.
+* `check_point` on `DefaultManifold` accepts keyword arguments, so `is_point(M, p; atol=)` reaches it instead of the generic check.
+* the allocating `project(M::EmbeddedManifold, p, X)` allocates in the representation size of the base manifold, not of the embedding.
+
 ## [2.5.1] 02/09/2026
 
 ### Fixed

--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * [DocumenterCodeBlocks.jl](https://fredrikekre.github.io/DocumenterCodeBlocks.jl/stable/) plugin added to the documentation
 * [DocumenterLandingPage.jl](https://csvance.github.io/DocumenterLandingPage.jl/) enhances the start page with a short teaser for the package now.
+* `is_flat(::VectorSpaceFiber)`, so a `CotangentSpace` and any user-defined vector space fiber report the flatness `Fiber` documents; before only `TangentSpace` had a method.
+* scalar multiplication from the right for `FVector` and `ZeroVector`, mirroring the existing `a * X` methods.
 
 ### Fixed
 
@@ -34,6 +36,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `check_vector` of `ManifoldsBase.Test.TestSphere` takes an `atol`, defaulting to `sqrt(prod(representation_size(M))) * eps`.
 * `check_point` on `DefaultManifold` accepts keyword arguments, so `is_point(M, p; atol=)` reaches it instead of the generic check.
 * the allocating `project(M::EmbeddedManifold, p, X)` allocates in the representation size of the base manifold, not of the embedding.
+* `change_representer!`, `change_metric!` and `Weingarten!` now have a `PowerManifoldNestedReplacing` method; before they reached `_write`, which that representation does not define.
+* `show` of a `CachedBasis` on a power manifold prints the basis type instead of constructing it, which failed for any basis type with a field, for example `DiagonalizingOrthonormalBasis`.
+* `distance(M, p, q, r)` and `norm(M, p, X, r)` on a power manifold seed their reduction in `real(float(number_eltype(p)))` for `r = 1` and `r = Inf`; on a complex power manifold the first errored and the second returned a complex value.
+* `get_basis` on a `ProductManifold` splits its point with `submanifold_components(M, p)`, so point types that implement only the two-argument form work as well.
+* `get_coordinates!` and `get_vector!` default their basis to `default_basis(M, typeof(p))`, matching the allocating variants; before they hard-coded `DefaultOrthonormalBasis()`, so the two disagreed for any manifold specializing `default_basis`.
+* `retract_fused` includes `t` in its `allocate_result`, as `exp_fused` does; before a fused retraction allocated in the element type of `p` and `X` alone.
+* `retract_fused`, the two `_retract_fused` methods, the `SasakiRetraction` and `StabilizedRetraction` layer-2 and layer-3 methods, and `inverse_retract_embedded!` accept and forward `kwargs...`, so `RetractionWithKeywords` and `InverseRetractionWithKeywords` reach the last layer instead of raising a `MethodError`.
+* `ShootingInverseRetraction` runs `max_iterations` iterations; the loop guard was strict, so `max_iterations = 1` shot not at all and `n` gave the accuracy of `n - 1`.
+* `_inverse_retract!` for `ShootingInverseRetraction` accepts `kwargs...` and forwards them to the retraction of its loop.
+* `manifold_dimension` on an `AbstractDecoratorManifold` that decorates nothing throws a `MethodError` instead of recursing into a `StackOverflowError`.
+
+### Changed
+
+* `show` for a `Fiber` prints the fiber type and the base manifold on separate lines instead of concatenating them.
+* `inverse_retract` and `inverse_retract!` accept keyword arguments, like `retract` and `retract!` already did.
 
 ## [2.5.1] 02/09/2026
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.5.2] unreleased
+## [2.6.0] unreleased
 
 ### Added
 
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `ShootingInverseRetraction` runs `max_iterations` iterations; the loop guard was strict, so `max_iterations = 1` shot not at all and `n` gave the accuracy of `n - 1`.
 * `_inverse_retract!` for `ShootingInverseRetraction` accepts `kwargs...` and forwards them to the retraction of its loop.
 * `manifold_dimension` on an `AbstractDecoratorManifold` that decorates nothing throws a `MethodError` instead of recursing into a `StackOverflowError`.
+* `get_forwarding_type_embedding` no longer inverts the embedding directness, and the three `AbstractEmbeddingType` constructors default to `DirectEmbedding()`; a manifold declaring `DirectEmbedding()` is now forwarded directly, as documented.
 
 ### Changed
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ManifoldsBase"
 uuid = "3362f125-f0bb-47a3-aa74-596ffd7ef2fb"
-version = "2.5.1"
+version = "2.6.0"
 authors = ["Seth Axen <seth.axen@gmail.com>", "Mateusz Baran <mateuszbaran89@gmail.com>", "Ronny Bergmann <manopt@ronnybergmann.net>", "Antoine Levitt <antoine.levitt@gmail.com>"]
 
 [workspace]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -130,6 +130,7 @@ end
 bib = CitationBibliography(joinpath(@__DIR__, "src", "references.bib"); style = :alpha)
 links = InterLinks(
     "Julia" => "https://docs.julialang.org/en/v1/",
+    "LieGroups" => ("https://juliamanifolds.github.io/LieGroups.jl/stable/"),
     "Manifolds" => ("https://juliamanifolds.github.io/Manifolds.jl/stable/"),
 )
 makedocs(;

--- a/ext/ManifoldsBaseRecursiveArrayToolsExt/ProductManifoldRecursiveArrayToolsExt.jl
+++ b/ext/ManifoldsBaseRecursiveArrayToolsExt/ProductManifoldRecursiveArrayToolsExt.jl
@@ -18,9 +18,7 @@ function allocate_on(M::ProductManifold, ft::TangentSpaceType, ::Type{ArrayParti
     return ArrayPartition(map(N -> allocate_on(N, ft), M.manifolds)...)
 end
 function allocate_on(
-        M::ProductManifold,
-        ft::TangentSpaceType,
-        ::Type{ArrayPartition{T, U}},
+        M::ProductManifold, ft::TangentSpaceType, ::Type{ArrayPartition{T, U}},
     ) where {T, U}
     return ArrayPartition(
         map((N, V) -> allocate_on(N, ft, V), M.manifolds, U.parameters)...,
@@ -40,10 +38,7 @@ function copyto!(M::ProductManifold, q::ArrayPartition, p::ArrayPartition)
     return q
 end
 function copyto!(
-        M::ProductManifold,
-        Y::ArrayPartition,
-        p::ArrayPartition,
-        X::ArrayPartition,
+        M::ProductManifold, Y::ArrayPartition, p::ArrayPartition, X::ArrayPartition,
     )
     map(
         copyto!,
@@ -63,8 +58,7 @@ function default_retraction_method(M::ProductManifold, ::Type{T}) where {T <: Ar
 end
 
 function default_inverse_retraction_method(
-        M::ProductManifold,
-        ::Type{T},
+        M::ProductManifold, ::Type{T},
     ) where {T <: ArrayPartition}
     return InverseProductRetraction(
         map(default_inverse_retraction_method, M.manifolds, T.parameters[2].parameters)...,
@@ -72,8 +66,7 @@ function default_inverse_retraction_method(
 end
 
 function default_vector_transport_method(
-        M::ProductManifold,
-        ::Type{T},
+        M::ProductManifold, ::Type{T},
     ) where {T <: ArrayPartition}
     return ProductVectorTransport(
         map(default_vector_transport_method, M.manifolds, T.parameters[2].parameters)...,
@@ -91,10 +84,7 @@ function Base.exp(M::ProductManifold, p::ArrayPartition, X::ArrayPartition)
     )
 end
 function ManifoldsBase.exp_fused(
-        M::ProductManifold,
-        p::ArrayPartition,
-        X::ArrayPartition,
-        t::Number,
+        M::ProductManifold, p::ArrayPartition, X::ArrayPartition, t::Number,
     )
     return ArrayPartition(
         map(
@@ -107,10 +97,7 @@ function ManifoldsBase.exp_fused(
 end
 
 function get_vector(
-        M::ProductManifold,
-        p::ArrayPartition,
-        Xⁱ,
-        B::AbstractBasis{𝔽, TangentSpaceType},
+        M::ProductManifold, p::ArrayPartition, Xⁱ, B::AbstractBasis{𝔽, TangentSpaceType},
     ) where {𝔽}
     dims = map(manifold_dimension, M.manifolds)
     @assert length(Xⁱ) == sum(dims)
@@ -120,9 +107,7 @@ function get_vector(
     return ArrayPartition(map((@inline t -> get_vector(t..., B)), ts))
 end
 function get_vector(
-        M::ProductManifold,
-        p::ArrayPartition,
-        Xⁱ,
+        M::ProductManifold, p::ArrayPartition, Xⁱ,
         B::CachedBasis{𝔽, <:AbstractBasis{𝔽}, <:ProductBasisData},
     ) where {𝔽}
     dims = map(manifold_dimension, M.manifolds)
@@ -134,8 +119,7 @@ function get_vector(
 end
 
 function get_vectors(
-        M::ProductManifold,
-        p::ArrayPartition,
+        M::ProductManifold, p::ArrayPartition,
         B::CachedBasis{𝔽, <:AbstractBasis{𝔽}, <:ProductBasisData},
     ) where {𝔽}
     N = number_of_components(M)
@@ -171,10 +155,7 @@ See also [Array Indexing](https://docs.julialang.org/en/v1/manual/arrays/#man-ar
 end
 
 function inverse_retract(
-        M::ProductManifold,
-        p::ArrayPartition,
-        q::ArrayPartition,
-        method::InverseProductRetraction,
+        M::ProductManifold, p::ArrayPartition, q::ArrayPartition, method::InverseProductRetraction,
     )
     return ArrayPartition(
         map(
@@ -199,10 +180,7 @@ function Base.log(M::ProductManifold, p::ArrayPartition, q::ArrayPartition)
 end
 
 function parallel_transport_direction(
-        M::ProductManifold,
-        p::ArrayPartition,
-        X::ArrayPartition,
-        d::ArrayPartition,
+        M::ProductManifold, p::ArrayPartition, X::ArrayPartition, d::ArrayPartition,
     )
     return ArrayPartition(
         map(
@@ -216,10 +194,7 @@ function parallel_transport_direction(
 end
 
 function parallel_transport_to(
-        M::ProductManifold,
-        p::ArrayPartition,
-        X::ArrayPartition,
-        q::ArrayPartition,
+        M::ProductManifold, p::ArrayPartition, X::ArrayPartition, q::ArrayPartition,
     )
     return ArrayPartition(
         map(
@@ -254,8 +229,7 @@ a tuple of keyword arguments for `rand` on each manifold in `M.manifolds`.
 """
 function Random.rand(
         M::ProductManifold;
-        vector_at = nothing,
-        parts_kwargs = map(_ -> (;), M.manifolds),
+        vector_at = nothing, parts_kwargs = map(_ -> (;), M.manifolds),
     )
     if vector_at === nothing
         return ArrayPartition(
@@ -273,10 +247,8 @@ function Random.rand(
     end
 end
 function Random.rand(
-        rng::AbstractRNG,
-        M::ProductManifold;
-        vector_at = nothing,
-        parts_kwargs = map(_ -> (;), M.manifolds),
+        rng::AbstractRNG, M::ProductManifold;
+        vector_at = nothing, parts_kwargs = map(_ -> (;), M.manifolds),
     )
     if vector_at === nothing
         return ArrayPartition(
@@ -295,11 +267,7 @@ function Random.rand(
 end
 
 function riemann_tensor(
-        M::ProductManifold,
-        p::ArrayPartition,
-        X::ArrayPartition,
-        Y::ArrayPartition,
-        Z::ArrayPartition,
+        M::ProductManifold, p::ArrayPartition, X::ArrayPartition, Y::ArrayPartition, Z::ArrayPartition,
     )
     return ArrayPartition(
         map(
@@ -335,11 +303,7 @@ end
 @inline submanifold_components(p::ArrayPartition) = p.x
 
 function vector_transport_direction(
-        M::ProductManifold,
-        p::ArrayPartition,
-        X::ArrayPartition,
-        d::ArrayPartition,
-        m::ProductVectorTransport,
+        M::ProductManifold, p::ArrayPartition, X::ArrayPartition, d::ArrayPartition, m::ProductVectorTransport,
     )
     return ArrayPartition(
         map(
@@ -354,11 +318,7 @@ function vector_transport_direction(
 end
 
 function vector_transport_to(
-        M::ProductManifold,
-        p::ArrayPartition,
-        X::ArrayPartition,
-        q::ArrayPartition,
-        m::ProductVectorTransport,
+        M::ProductManifold, p::ArrayPartition, X::ArrayPartition, q::ArrayPartition, m::ProductVectorTransport,
     )
     return ArrayPartition(
         map(
@@ -372,11 +332,7 @@ function vector_transport_to(
     )
 end
 function vector_transport_to(
-        M::ProductManifold,
-        p::ArrayPartition,
-        X::ArrayPartition,
-        q::ArrayPartition,
-        m::ParallelTransport,
+        M::ProductManifold, p::ArrayPartition, X::ArrayPartition, q::ArrayPartition, m::ParallelTransport,
     )
     return ArrayPartition(
         map(

--- a/ext/ManifoldsBaseStatisticsExt.jl
+++ b/ext/ManifoldsBaseStatisticsExt.jl
@@ -5,11 +5,8 @@ using ManifoldsBase
 import ManifoldsBase: find_best_slope_window
 
 function ManifoldsBase.find_best_slope_window(
-        X,
-        Y,
-        window = nothing;
-        slope::Real = 2.0,
-        slope_tol::Real = 0.1,
+        X, Y, window = nothing;
+        slope::Real = 2.0, slope_tol::Real = 0.1,
     )
     n = length(X)
     if window !== nothing && (any(window .> n))

--- a/src/DefaultManifold.jl
+++ b/src/DefaultManifold.jl
@@ -58,7 +58,7 @@ function check_approx(M::DefaultManifold, p, X, Y; kwargs...)
 end
 
 
-function check_point(M::DefaultManifold{𝔽}, p) where {𝔽}
+function check_point(M::DefaultManifold{𝔽}, p; kwargs...) where {𝔽}
     if (𝔽 === ℝ) && !(eltype(p) <: Real)
         return DomainError(
             eltype(p),

--- a/src/DefaultManifold.jl
+++ b/src/DefaultManifold.jl
@@ -30,9 +30,7 @@ function DefaultManifold(n::Vararg{Int}; field = ℝ, parameter::Symbol = :field
 end
 
 function allocation_promotion_function(
-        ::DefaultManifold{ℂ},
-        ::Union{typeof(get_vector), typeof(get_coordinates)},
-        ::Tuple,
+        ::DefaultManifold{ℂ}, ::Union{typeof(get_vector), typeof(get_coordinates)}, ::Tuple,
     )
     return complex
 end
@@ -203,11 +201,8 @@ function Random.rand!(::DefaultManifold, pX; σ = one(eltype(pX)), vector_at = n
     return pX
 end
 function Random.rand!(
-        rng::AbstractRNG,
-        ::DefaultManifold,
-        pX;
-        σ = one(eltype(pX)),
-        vector_at = nothing,
+        rng::AbstractRNG, ::DefaultManifold, pX;
+        σ = one(eltype(pX)), vector_at = nothing,
     )
     pX .= randn(rng, size(pX)) .* σ
     return pX

--- a/src/EmbeddedManifold.jl
+++ b/src/EmbeddedManifold.jl
@@ -72,6 +72,13 @@ function project(M::EmbeddedManifold, p)
     return q
 end
 
+function project(M::EmbeddedManifold, p, X)
+    # the order of args switched, since the allocation by default takes the type of the first.
+    Y = allocate_result(M, project, X, p)
+    project!(M, Y, p, X)
+    return Y
+end
+
 function show(
         io::IO, M::EmbeddedManifold{𝔽, MT, NT},
     ) where {𝔽, MT <: AbstractManifold{𝔽}, NT <: AbstractManifold}

--- a/src/Fiber.jl
+++ b/src/Fiber.jl
@@ -35,9 +35,7 @@ struct Fiber{𝔽, TFiber <: FiberType, TM <: AbstractManifold, TX} <: AbstractM
 end
 
 function Fiber(
-        manifold::TM,
-        point::TX,
-        fiber_type::TFiber;
+        manifold::TM, point::TX, fiber_type::TFiber;
         field::AbstractNumbers = ℝ,
     ) where {TM <: AbstractManifold, TX, TFiber <: FiberType}
     return Fiber{field, TFiber, TM, TX}(manifold, point, fiber_type)

--- a/src/Fiber.jl
+++ b/src/Fiber.jl
@@ -18,13 +18,15 @@ isometric to the [`Euclidean`](https://juliamanifolds.github.io/Manifolds.jl/lat
 * `manifold`    – base space of the fiber bundle
 * `point`       – a point ``p`` from the base space; the fiber corresponds to the preimage
                   by bundle projection ``\pi^{-1}(\{p\})``.
+* `fiber_type`  – the [`FiberType`](@ref) of the fiber
 
 
 # Constructor
 
-    Fiber(M::AbstractManifold, p, fiber_type::FiberType)
+    Fiber(M::AbstractManifold, p, fiber_type::FiberType; field::AbstractNumbers = ℝ)
 
-A fiber of type `fiber_type` at point `p` from the manifold `manifold`.
+A fiber of type `fiber_type` at point `p` from the manifold `M`.
+The number system `field` of the fiber defaults to `ℝ`.
 """
 struct Fiber{𝔽, TFiber <: FiberType, TM <: AbstractManifold, TX} <: AbstractManifold{𝔽}
     manifold::TM
@@ -51,7 +53,8 @@ function Base.show(io::IO, ::MIME"text/plain", vs::Fiber)
     sf = replace(sf, '\n' => "\n$(pre)")
     sm = sprint(show, "text/plain", vs.manifold; context = io, sizehint = 0)
     sm = replace(sm, '\n' => "\n$(pre)")
-    println(io, pre, sf, sm)
+    println(io, pre, sf)
+    println(io, pre, sm)
     println(io, "Base point:")
     sp = sprint(show, "text/plain", vs.point; context = io, sizehint = 0)
     sp = replace(sp, '\n' => "\n$(pre)")

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -846,11 +846,8 @@ The second signature is a shorthand, where the boolean is used for `error=:error
 and `error=:none` (default, `false`). This case ignores the `error=` keyword
 """
 function is_point(
-        M::AbstractManifold,
-        p,
-        throw_error::Bool;
-        error::Symbol = :none,
-        kwargs...,
+        M::AbstractManifold, p, throw_error::Bool;
+        error::Symbol = :none, kwargs...,
     )
     return is_point(M, p; error = throw_error ? :error : :none, kwargs...)
 end

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -228,7 +228,7 @@ Compute the angle between tangent vectors `X` and `Y` at point `p` from the
 [`AbstractManifold`](@ref) `M` with respect to the inner product from [`inner`](@ref).
 """
 function angle(M::AbstractManifold, p, X, Y)
-    return acos(real(inner(M, p, X, Y)) / norm(M, p, X) / norm(M, p, Y))
+    return acos(clamp(real(inner(M, p, X, Y)) / norm(M, p, X) / norm(M, p, Y), -1, 1))
 end
 
 """

--- a/src/ManifoldsBase.jl
+++ b/src/ManifoldsBase.jl
@@ -232,9 +232,10 @@ function angle(M::AbstractManifold, p, X, Y)
 end
 
 """
-    are_linearly_independent(M::AbstractManifold, p, X, Y)
+    are_linearly_independent(M::AbstractManifold, p, X, Y; atol::Real = sqrt(eps(number_eltype(X))))
 
-Check is vectors `X`, `Y` tangent at `p` to `M` are linearly independent.
+Check whether the vectors `X`, `Y` tangent at `p` to `M` are linearly independent.
+The keyword `atol` is the tolerance below which a tangent vector is considered to be zero.
 """
 function are_linearly_independent(
         M::AbstractManifold, p, X, Y; atol::Real = sqrt(eps(number_eltype(X))),
@@ -298,7 +299,7 @@ function check_approx(M::AbstractManifold, p, X, Y; kwargs...)
 end
 
 """
-    check_point(M::AbstractManifold, p; kwargs...) -> Union{Nothing,String}
+    check_point(M::AbstractManifold, p; kwargs...) -> Union{Nothing,Exception}
 
 Return `nothing` when `p` is a point on the [`AbstractManifold`](@ref) `M`. Otherwise, return an
 error with description why the point does not belong to manifold `M`.
@@ -309,11 +310,11 @@ assumption is to be optimistic for a point not deriving from the [`AbstractManif
 check_point(M::AbstractManifold, p; kwargs...) = nothing
 
 """
-    check_vector(M::AbstractManifold, p, X; kwargs...) -> Union{Nothing,String}
+    check_vector(M::AbstractManifold, p, X; kwargs...) -> Union{Nothing,Exception}
 
 Check whether `X` is a valid tangent vector in the tangent space of `p` on the
 [`AbstractManifold`](@ref) `M`. An implementation does not have to validate the point `p`.
-If it is not a tangent vector, an error string should be returned.
+If it is not a tangent vector, an error should be returned.
 
 By default, `check_vector` returns `nothing`, i.e. if no checks are implemented, the
 assumption is to be optimistic for tangent vectors not deriving from the [`AbstractTangentVector`](@ref)
@@ -762,12 +763,12 @@ function isapprox(M::AbstractManifold, p, q; error::Symbol = :none, kwargs...)
 end
 
 """
-    isapprox(M::AbstractManifold, p, X, Y; error:Symbol=:none; kwargs...)
+    isapprox(M::AbstractManifold, p, X, Y; error::Symbol=:none, kwargs...)
 
 Check if vectors `X` and `Y` tangent at `p` from [`AbstractManifold`](@ref) `M` are approximately
 equal.
 
-The optional positional argument can be used to get more information for the case that
+The keyword argument can be used to get more information for the case that
 the result is false, if the concrete manifold provides such information.
 Currently the following are supported
 
@@ -830,7 +831,7 @@ end
     is_point(M::AbstractManifold, p, throw_error::Bool; kwargs...)
 
 Return whether `p` is a valid point on the [`AbstractManifold`](@ref) `M`.
-By default the function calls [`check_point`](@ref), which returns an `ErrorException` or `nothing`.
+By default the function calls [`check_point`](@ref), which returns an `Exception` or `nothing`.
 
 How to report a potential error can be set using the `error=` keyword
 
@@ -969,7 +970,7 @@ Calculate the middle between the two point `p1` and `p2` from manifold `M`.
 By default uses [`log`](@ref), divides the vector by 2 and uses [`exp`](@ref).
 """
 function mid_point(M::AbstractManifold, p1, p2)
-    q = allocate(p1)
+    q = allocate_result(M, mid_point, p1, p2)
     return mid_point!(M, q, p1, p2)
 end
 
@@ -1132,7 +1133,7 @@ end
 
 Upper bound on sectional curvature of manifold `M`. The formula reads
 ```math
-\omega = \operatorname{sup}_{p\in\mathcal M, X\in T_p\mathcal M, Y\in T_p\mathcal M, ⟨X, Y⟩ ≠ 0} \kappa_p(X, Y)
+\omega = \operatorname{sup}_{p\in\mathcal M, X\in T_p\mathcal M, Y\in T_p\mathcal M, \lVert X \rVert^2_p \lVert Y \rVert^2_p - ⟨X, Y⟩^2_p ≠ 0} \kappa_p(X, Y)
 ```
 """
 sectional_curvature_max(M::AbstractManifold)
@@ -1142,7 +1143,7 @@ sectional_curvature_max(M::AbstractManifold)
 
 Lower bound on sectional curvature of manifold `M`. The formula reads
 ```math
-\omega = \operatorname{inf}_{p\in\mathcal M, X\in T_p\mathcal M, Y\in T_p\mathcal M, ⟨X, Y⟩ ≠ 0} \kappa_p(X, Y)
+\omega = \operatorname{inf}_{p\in\mathcal M, X\in T_p\mathcal M, Y\in T_p\mathcal M, \lVert X \rVert^2_p \lVert Y \rVert^2_p - ⟨X, Y⟩^2_p ≠ 0} \kappa_p(X, Y)
 ```
 """
 sectional_curvature_min(M::AbstractManifold)
@@ -1224,7 +1225,7 @@ end
 # Internal function to set plotting backend
 
 """
-    set_plotting_backend!(backend::String; only_fallback = false)
+    set_plotting_backend!(backend::String)
 
 Set the plotting backend to `backend`.
 Currently supported: `"Plots"` and `"Makie"`.

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -155,43 +155,29 @@ const PowerManifoldNestedReplacing = AbstractPowerManifold{
 @inline _access_nested(x, i::Tuple) = x[i...]
 
 function Base.:^(
-        M::PowerManifold{
-            𝔽, TM, TSize, <:Union{NestedPowerRepresentation, NestedReplacingPowerRepresentation},
-        }, size::Integer...,
+        M::PowerManifold{𝔽, TM, TSize, <:Union{NestedPowerRepresentation, NestedReplacingPowerRepresentation}}, size::Integer...,
     ) where {𝔽, TM <: AbstractManifold{𝔽}, TSize}
     return PowerManifold(M, size...)
 end
 
 function allocate_on(
-        M::PowerManifold{
-            𝔽, TM, TSize, <:Union{NestedPowerRepresentation, NestedReplacingPowerRepresentation},
-        },
+        M::PowerManifold{𝔽, TM, TSize, <:Union{NestedPowerRepresentation, NestedReplacingPowerRepresentation}},
     ) where {𝔽, TM <: AbstractManifold{𝔽}, TSize}
     return [allocate_on(M.manifold) for _ in get_iterator(M)]
 end
 function allocate_on(
-        M::PowerManifold{
-            𝔽, TM, TSize, <:Union{NestedPowerRepresentation, NestedReplacingPowerRepresentation},
-        },
-        ::Type{<:Array{U}},
+        M::PowerManifold{𝔽, TM, TSize, <:Union{NestedPowerRepresentation, NestedReplacingPowerRepresentation}}, ::Type{<:Array{U}},
     ) where {𝔽, TM <: AbstractManifold{𝔽}, TSize, U}
     return [allocate_on(M.manifold, U) for _ in get_iterator(M)]
 end
 
 function allocate_on(
-        M::PowerManifold{
-            𝔽, TM, TSize, <:Union{NestedPowerRepresentation, NestedReplacingPowerRepresentation},
-        },
-        ft::TangentSpaceType,
+        M::PowerManifold{𝔽, TM, TSize, <:Union{NestedPowerRepresentation, NestedReplacingPowerRepresentation}}, ft::TangentSpaceType,
     ) where {𝔽, TM <: AbstractManifold{𝔽}, TSize}
     return [allocate_on(M.manifold, ft) for _ in get_iterator(M)]
 end
 function allocate_on(
-        M::PowerManifold{
-            𝔽, TM, TSize, <:Union{NestedPowerRepresentation, NestedReplacingPowerRepresentation},
-        },
-        ft::TangentSpaceType,
-        ::Type{<:Array{U}},
+        M::PowerManifold{𝔽, TM, TSize, <:Union{NestedPowerRepresentation, NestedReplacingPowerRepresentation}}, ft::TangentSpaceType, ::Type{<:Array{U}},
     ) where {𝔽, TM <: AbstractManifold{𝔽}, TSize, U}
     return [allocate_on(M.manifold, ft, U) for _ in get_iterator(M)]
 end
@@ -248,16 +234,14 @@ function allocate_result(M::PowerManifoldNestedReplacing, f, x...)
     end
 end
 function allocate_result_embedding(
-        ::PowerManifoldNestedReplacing,
-        ::typeof(project),
-        x,
-        args...
+        ::PowerManifoldNestedReplacing, ::typeof(project), x, args...,
     )
     return copy(x)
 end
 # the following is not used but necessary to avoid ambiguities
 function allocate_result(
-        M::PowerManifoldNestedReplacing, f::typeof(get_coordinates), p, X, B::AbstractBasis,
+        M::PowerManifoldNestedReplacing, f::typeof(get_coordinates), p, X,
+        B::AbstractBasis,
     )
     return invoke(
         allocate_result,
@@ -550,8 +534,7 @@ end
 
 @doc "$(_doc_distance_pow)"
 function distance(
-        M::AbstractPowerManifold,
-        p, q, m::AbstractInverseRetractionMethod, r::Real = 2,
+        M::AbstractPowerManifold, p, q, m::AbstractInverseRetractionMethod, r::Real = 2,
     )
     (isinf(r) && r > 0) && return _distance_max(M, p, q, m)
     (isinf(r) && r < 0) && return _distance_min(M, p, q, m)
@@ -771,8 +754,7 @@ end
 _get_field(::AbstractManifold{𝔽}) where {𝔽} = 𝔽
 
 function get_embedding(
-        M::PowerManifold{𝔽, TM, TSW, TPR},
-        P::Type,
+        M::PowerManifold{𝔽, TM, TSW, TPR}, P::Type,
     ) where {𝔽, TM <: AbstractManifold{𝔽}, TSW, TPR <: Union{NestedPowerRepresentation, NestedReplacingPowerRepresentation}}
     ME = get_embedding(M.manifold, eltype(P))
     return PowerManifold{_get_field(ME), typeof(ME), TSW, TPR}(ME, M.size)
@@ -1026,16 +1008,14 @@ retraction method has to be one that is available on the base [`AbstractManifold
 inverse_retract(::AbstractPowerManifold, ::Any...)
 
 function inverse_retract(
-        M::AbstractPowerManifold, p, q,
-        m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
+        M::AbstractPowerManifold, p, q, m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
     )
     X = allocate_result(M, inverse_retract, p, q)
     return inverse_retract!(M, X, p, q, m)
 end
 
 function inverse_retract!(
-        M::AbstractPowerManifold, X, p, q,
-        m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
+        M::AbstractPowerManifold, X, p, q, m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
     )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1046,8 +1026,7 @@ function inverse_retract!(
     return X
 end
 function inverse_retract!(
-        M::PowerManifoldNestedReplacing, X, p, q,
-        m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
+        M::PowerManifoldNestedReplacing, X, p, q, m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
     )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1380,8 +1359,7 @@ function retract(
 end
 
 function retract!(
-        M::AbstractPowerManifold, q, p, X,
-        m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
+        M::AbstractPowerManifold, q, p, X, m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
     )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1402,8 +1380,7 @@ function retract!(
 end
 
 function retract_fused!(
-        M::AbstractPowerManifold, q, p, X, t::Number,
-        m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
+        M::AbstractPowerManifold, q, p, X, t::Number, m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
     )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1414,8 +1391,7 @@ function retract_fused!(
     return q
 end
 function retract_fused!(
-        M::PowerManifoldNestedReplacing, q, p, X, t::Number,
-        m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
+        M::PowerManifoldNestedReplacing, q, p, X, t::Number, m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
     )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1540,8 +1516,7 @@ Base.@propagate_inbounds function Base.setindex!(
 end
 
 function Base.show(
-        io::IO,
-        M::PowerManifold{𝔽, TM, TSize, TPR},
+        io::IO, M::PowerManifold{𝔽, TM, TSize, TPR},
     ) where {𝔽, TM <: AbstractManifold{𝔽}, TSize, TPR <: AbstractPowerRepresentation}
     size = get_parameter(M.size)
     return print(io, "PowerManifold($(M.manifold), $(TPR()), $(join(size, ", ")))")
@@ -1569,8 +1544,7 @@ function Base.show(
 end
 
 function vector_transport_direction!(
-        M::AbstractPowerManifold, Y, p, X, d,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::AbstractPowerManifold, Y, p, X, d, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1582,16 +1556,14 @@ function vector_transport_direction!(
     return Y
 end
 function vector_transport_direction(
-        M::AbstractPowerManifold, p, X, d,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::AbstractPowerManifold, p, X, d, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     Y = allocate_result(M, vector_transport_direction, p, X, d)
     return vector_transport_direction!(M, Y, p, X, d, m)
 end
 
 function vector_transport_direction!(
-        M::PowerManifoldNestedReplacing, Y, p, X, d,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::PowerManifoldNestedReplacing, Y, p, X, d, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1602,8 +1574,7 @@ function vector_transport_direction!(
     return Y
 end
 function vector_transport_direction(
-        M::PowerManifoldNestedReplacing, p, X, d,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::PowerManifoldNestedReplacing, p, X, d, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     Y = allocate_result(M, vector_transport_direction, p, X, d)
     rep_size = representation_size(M.manifold)
@@ -1631,15 +1602,13 @@ vector_transport_to(
     ::AbstractVectorTransportMethod,
 )
 function vector_transport_to(
-        M::AbstractPowerManifold, p, X, q,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::AbstractPowerManifold, p, X, q, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     Y = allocate_result(M, vector_transport_to, p, X)
     return vector_transport_to!(M, Y, p, X, q, m)
 end
 function vector_transport_to!(
-        M::AbstractPowerManifold, Y, p, X, q,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::AbstractPowerManifold, Y, p, X, q, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
@@ -1651,8 +1620,7 @@ function vector_transport_to!(
     return Y
 end
 function vector_transport_to!(
-        M::PowerManifoldNestedReplacing, Y, p, X, q,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::PowerManifoldNestedReplacing, Y, p, X, q, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -59,7 +59,7 @@ would not be represented by statically-sized arrays.
 
 # Constructor
 
-    PowerManifold(M::PowerManifold, N_1, N_2, ..., N_d; parameter::Symbol=:field)
+    PowerManifold(M::PowerManifold, N_1, N_2, ..., N_d; parameter::Symbol=_parameter_symbol(M))
     PowerManifold(M::AbstractManifold, NestedPowerRepresentation(), N_1, N_2, ..., N_d; parameter::Symbol=:field)
     M^(N_1, N_2, ..., N_d)
 
@@ -79,7 +79,8 @@ Since there is no default [`AbstractPowerRepresentation`](@ref) within this inte
 `^` operator is only available for `PowerManifold`s and concatenates dimensions.
 
 `parameter`: whether a type parameter should be used to store `n`. By default size
-is stored in a field. Value can either be `:field` or `:type`.
+is stored in a field, unless `M` is a [`PowerManifold`](@ref), then its storage is
+inherited. Value can either be `:field` or `:type`.
 """
 struct PowerManifold{𝔽, TM <: AbstractManifold{𝔽}, TSize, TPR <: AbstractPowerRepresentation} <:
     AbstractPowerManifold{𝔽, TM, TPR}
@@ -292,6 +293,15 @@ function change_representer!(M::AbstractPowerManifold, Y, G::AbstractMetric, p, 
     end
     return Y
 end
+function change_representer!(M::PowerManifoldNestedReplacing, Y, G::AbstractMetric, p, X)
+    rep_size = representation_size(M.manifold)
+    for i in get_iterator(M)
+        Y[i...] = change_representer(
+            M.manifold, G, _read(M, rep_size, p, i), _read(M, rep_size, X, i),
+        )
+    end
+    return Y
+end
 
 """
     change_metric(M::AbstractPowerManifold, ::AbstractMetric, p, X)
@@ -305,6 +315,15 @@ function change_metric!(M::AbstractPowerManifold, Y, G::AbstractMetric, p, X)
     for i in get_iterator(M)
         change_metric!(
             M.manifold, _write(M, rep_size, Y, i), G, _read(M, rep_size, p, i), _read(M, rep_size, X, i),
+        )
+    end
+    return Y
+end
+function change_metric!(M::PowerManifoldNestedReplacing, Y, G::AbstractMetric, p, X)
+    rep_size = representation_size(M.manifold)
+    for i in get_iterator(M)
+        Y[i...] = change_metric(
+            M.manifold, G, _read(M, rep_size, p, i), _read(M, rep_size, X, i),
         )
     end
     return Y
@@ -561,7 +580,7 @@ function _distance_r(M::AbstractPowerManifold, p, q, r::Real)
     return norm(values, r)
 end
 function _distance_1(M::AbstractPowerManifold, p, q, m::AbstractInverseRetractionMethod)
-    s = zero(number_eltype(p))
+    s = zero(real(float(number_eltype(p))))
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
         s += distance(M.manifold, _read(M, rep_size, p, i), _read(M, rep_size, q, i), m)
@@ -569,7 +588,7 @@ function _distance_1(M::AbstractPowerManifold, p, q, m::AbstractInverseRetractio
     return s
 end
 function _distance_1(M::AbstractPowerManifold, p, q)
-    s = zero(number_eltype(p))
+    s = zero(real(float(number_eltype(p))))
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
         s += distance(M.manifold, _read(M, rep_size, p, i), _read(M, rep_size, q, i))
@@ -577,7 +596,7 @@ function _distance_1(M::AbstractPowerManifold, p, q)
     return s
 end
 function _distance_max(M::AbstractPowerManifold, p, q, m::AbstractInverseRetractionMethod)
-    d = float(zero(number_eltype(p)))
+    d = zero(real(float(number_eltype(p))))
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
         v = distance(M.manifold, _read(M, rep_size, p, i), _read(M, rep_size, q, i), m)
@@ -586,7 +605,7 @@ function _distance_max(M::AbstractPowerManifold, p, q, m::AbstractInverseRetract
     return d
 end
 function _distance_max(M::AbstractPowerManifold, p, q)
-    d = float(zero(number_eltype(p)))
+    d = zero(real(float(number_eltype(p))))
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
         v = distance(M.manifold, _read(M, rep_size, p, i), _read(M, rep_size, q, i))
@@ -1121,7 +1140,7 @@ function _norm_r(M::AbstractPowerManifold, p, X, r::Real)
     return norm(values, r)
 end
 function _norm_1(M::AbstractPowerManifold, p, X)
-    s = zero(number_eltype(p))
+    s = zero(real(float(number_eltype(p))))
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
         s += norm(M.manifold, _read(M, rep_size, p, i), _read(M, rep_size, X, i))
@@ -1540,7 +1559,7 @@ end
 function Base.show(
         io::IO, mime::MIME"text/plain", B::CachedBasis{𝔽, T, D},
     ) where {T <: AbstractBasis, D <: PowerBasisData, 𝔽}
-    println(io, "$(T()) for a power manifold")
+    println(io, "$(T) for a power manifold")
     for i in Base.product(map(Base.OneTo, size(B.data.bases))...)
         println(io, "Basis for component $i:")
         show(io, mime, _access_nested(B.data.bases, i))
@@ -1672,6 +1691,15 @@ function Weingarten!(M::AbstractPowerManifold, Y, p, X, V)
         Weingarten!(
             M.manifold, _write(M, rep_size, Y, i),
             _read(M, rep_size, p, i), _read(M, rep_size, X, i), _read(M, rep_size, V, i),
+        )
+    end
+    return Y
+end
+function Weingarten!(M::PowerManifoldNestedReplacing, Y, p, X, V)
+    rep_size = representation_size(M.manifold)
+    for i in get_iterator(M)
+        Y[i...] = Weingarten(
+            M.manifold, _read(M, rep_size, p, i), _read(M, rep_size, X, i), _read(M, rep_size, V, i),
         )
     end
     return Y

--- a/src/PowerManifold.jl
+++ b/src/PowerManifold.jl
@@ -941,8 +941,8 @@ function injectivity_radius(M::AbstractPowerManifold, p)
     return radius
 end
 injectivity_radius(M::AbstractPowerManifold) = injectivity_radius(M.manifold)
-function injectivity_radius(M::AbstractPowerManifold, ::AbstractRetractionMethod)
-    return injectivity_radius(M)
+function injectivity_radius(M::AbstractPowerManifold, m::AbstractRetractionMethod)
+    return injectivity_radius(M.manifold, m)
 end
 
 @doc raw"""
@@ -1189,7 +1189,7 @@ end
 function parallel_transport_to!(M::AbstractPowerManifold, Y, p, X, q)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        vector_transport_to!(
+        parallel_transport_to!(
             M.manifold, _write(M, rep_size, Y, i), _read(M, rep_size, p, i), _read(M, rep_size, X, i), _read(M, rep_size, q, i),
         )
     end
@@ -1257,7 +1257,7 @@ end
 function project!(M::PowerManifoldNestedReplacing, Z, q, Y)
     rep_size = representation_size(M.manifold)
     for i in get_iterator(M)
-        q[i...] = project(M.manifold, _read(M, rep_size, q, i), _read(M, rep_size, Y, i))
+        Z[i...] = project(M.manifold, _read(M, rep_size, q, i), _read(M, rep_size, Y, i))
     end
     return Z
 end
@@ -1485,7 +1485,7 @@ manifolds, as the sectional curvature corresponding to the plane spanned by vect
 """
 function sectional_curvature_min(M::AbstractPowerManifold)
     d = prod(power_dimensions(M))
-    mscm = sectional_curvature_max(M.manifold)
+    mscm = sectional_curvature_min(M.manifold)
     if d > 1
         return min(mscm, zero(mscm))
     else

--- a/src/ProductManifold.jl
+++ b/src/ProductManifold.jl
@@ -39,7 +39,7 @@ function Base.getindex(TpM::TangentSpace{𝔽, <:ProductManifold}, i::Integer) w
     return TangentSpace(M[i], base_point(TpM)[M, i])
 end
 
-ProductManifold() = throw(MethodError("No method matching ProductManifold()."))
+ProductManifold() = throw(MethodError(ProductManifold, ()))
 
 const PRODUCT_BASIS_LIST = [
     VeeOrthogonalBasis,
@@ -176,13 +176,11 @@ function check_point(M::ProductManifold, p; kwargs...)
 end
 
 """
-    check_size(M::ProductManifold, p; kwargs...)
+    check_size(M::ProductManifold, p)
 
 Check whether `p` is of valid size on the [`ProductManifold`](@ref) `M`.
 If `p` has components of wrong size a [`CompositeManifoldError`](https://juliamanifolds.github.io/ManifoldsBase.jl/stable/functions.html#ManifoldsBase.CompositeManifoldError).consisting of all error messages of the
 components, for which the tests fail is returned.
-
-The tolerance for the last test can be set using the `kwargs...`.
 """
 function check_size(M::ProductManifold, p)
     try
@@ -456,7 +454,7 @@ function exp_fused!(M::ProductManifold, q, p, X, t::Number)
 end
 
 function get_basis(M::ProductManifold, p, B::AbstractBasis)
-    parts = map(t -> get_basis(t..., B), ziptuples(M.manifolds, submanifold_components(p)))
+    parts = map(t -> get_basis(t..., B), ziptuples(M.manifolds, submanifold_components(M, p)))
     return CachedBasis(B, ProductBasisData(parts))
 end
 function get_basis(M::ProductManifold, p, B::CachedBasis)
@@ -466,8 +464,8 @@ function get_basis(M::ProductManifold, p, B::DiagonalizingOrthonormalBasis)
     vs = map(
         ziptuples(
             M.manifolds,
-            submanifold_components(p),
-            submanifold_components(B.frame_direction),
+            submanifold_components(M, p),
+            submanifold_components(M, B.frame_direction),
         ),
     ) do t
         return get_basis(t[1], t[2], DiagonalizingOrthonormalBasis(t[3]))
@@ -1034,7 +1032,7 @@ For example `select_from_tuple(("a", "b", "c"), Val((3, 1, 1)))` returns
 """
 @generated function select_from_tuple(t::NTuple{N, Any}, positions::Val{P}) where {N, P}
     for k in P
-        (k < 0 || k > N) && error("positions must be between 1 and $N")
+        (k < 1 || k > N) && error("positions must be between 1 and $N")
     end
     return Expr(:tuple, [Expr(:ref, :t, k) for k in P]...)
 end
@@ -1276,7 +1274,7 @@ end
     submanifold_component(p, i::Integer)
     submanifold_component(p, ::Val{i}) where {i}
 
-Project the product array `p` on `M` to its `i`th component. A new array is returned.
+Project the product array `p` on `M` to its `i`th component.
 """
 submanifold_component(::Any...)
 @inline function submanifold_component(M::AbstractManifold, p, i::Integer)

--- a/src/ProductManifold.jl
+++ b/src/ProductManifold.jl
@@ -982,10 +982,13 @@ function sectional_curvature(M::ProductManifold, p, X, Y)
         submanifold_components(M, Y),
     ) do M_i, p_i, X_i, Y_i
         if are_linearly_independent(M_i, p_i, X_i, Y_i)
-            curvature += sectional_curvature(M_i, p_i, X_i, Y_i)
+            w_i =
+                inner(M_i, p_i, X_i, X_i) * inner(M_i, p_i, Y_i, Y_i) -
+                inner(M_i, p_i, X_i, Y_i)^2
+            curvature += w_i * sectional_curvature(M_i, p_i, X_i, Y_i)
         end
     end
-    return curvature
+    return curvature / (inner(M, p, X, X) * inner(M, p, Y, Y) - inner(M, p, X, Y)^2)
 end
 
 @doc raw"""

--- a/src/ProductManifold.jl
+++ b/src/ProductManifold.jl
@@ -311,20 +311,17 @@ If both [`InverseProductRetraction`](@ref)s, they are combined into one keeping 
 """
 cross(::AbstractInverseRetractionMethod...)
 function LinearAlgebra.cross(
-        m::AbstractInverseRetractionMethod,
-        n::AbstractInverseRetractionMethod,
+        m::AbstractInverseRetractionMethod, n::AbstractInverseRetractionMethod,
     )
     return InverseProductRetraction(m, n)
 end
 function LinearAlgebra.cross(
-        m::InverseProductRetraction,
-        n::AbstractInverseRetractionMethod,
+        m::InverseProductRetraction, n::AbstractInverseRetractionMethod,
     )
     return InverseProductRetraction(m.inverse_retractions..., n)
 end
 function LinearAlgebra.cross(
-        m::AbstractInverseRetractionMethod,
-        n::InverseProductRetraction,
+        m::AbstractInverseRetractionMethod, n::InverseProductRetraction,
     )
     return InverseProductRetraction(m, n.inverse_retractions...)
 end
@@ -346,8 +343,7 @@ If both [`ProductVectorTransport`](@ref)s, they are combined into one keeping th
 """
 cross(::AbstractVectorTransportMethod...)
 function LinearAlgebra.cross(
-        m::AbstractVectorTransportMethod,
-        n::AbstractVectorTransportMethod,
+        m::AbstractVectorTransportMethod, n::AbstractVectorTransportMethod,
     )
     return ProductVectorTransport(m, n)
 end
@@ -490,10 +486,7 @@ function get_coordinates(M::ProductManifold, p, X, B::AbstractBasis)
     return vcat(reps...)
 end
 function get_coordinates(
-        M::ProductManifold,
-        p,
-        X,
-        B::CachedBasis{𝔽, <:AbstractBasis{𝔽}, <:ProductBasisData},
+        M::ProductManifold, p, X, B::CachedBasis{𝔽, <:AbstractBasis{𝔽}, <:ProductBasisData},
     ) where {𝔽}
     reps = map(
         get_coordinates,
@@ -520,11 +513,7 @@ function get_coordinates!(M::ProductManifold, Xⁱ, p, X, B::AbstractBasis)
     return Xⁱ
 end
 function get_coordinates!(
-        M::ProductManifold,
-        Xⁱ,
-        p,
-        X,
-        B::CachedBasis{𝔽, <:AbstractBasis{𝔽}, <:ProductBasisData},
+        M::ProductManifold, Xⁱ, p, X, B::CachedBasis{𝔽, <:AbstractBasis{𝔽}, <:ProductBasisData},
     ) where {𝔽}
     dim = manifold_dimension(M)
     @assert length(Xⁱ) == dim
@@ -567,11 +556,7 @@ function get_vector!(M::ProductManifold, X, p, Xⁱ, B::AbstractBasis)
     return X
 end
 function get_vector!(
-        M::ProductManifold,
-        X,
-        p,
-        Xⁱ,
-        B::CachedBasis{𝔽, <:AbstractBasis{𝔽}, <:ProductBasisData},
+        M::ProductManifold, X, p, Xⁱ, B::CachedBasis{𝔽, <:AbstractBasis{𝔽}, <:ProductBasisData},
     ) where {𝔽}
     dims = map(manifold_dimension, M.manifolds)
     @assert length(Xⁱ) == sum(dims)
@@ -684,11 +669,7 @@ function inverse_retract!(M::ProductManifold, Y, p, q, method::InverseProductRet
     return Y
 end
 function inverse_retract!(
-        M::ProductManifold,
-        Y,
-        p,
-        q,
-        method::IRM,
+        M::ProductManifold, Y, p, q, method::IRM,
     ) where {IRM <: AbstractInverseRetractionMethod}
     map(
         (iM, iY, ip, iq) -> inverse_retract!(iM, iY, ip, iq, method),
@@ -824,10 +805,8 @@ function project!(M::ProductManifold, Y, p, X)
 end
 
 function Random.rand!(
-        M::ProductManifold,
-        pX;
-        vector_at = nothing,
-        parts_kwargs = map(_ -> (;), M.manifolds),
+        M::ProductManifold, pX;
+        vector_at = nothing, parts_kwargs = map(_ -> (;), M.manifolds),
     )
     return rand!(
         Random.default_rng(),
@@ -838,11 +817,8 @@ function Random.rand!(
     )
 end
 function Random.rand!(
-        rng::AbstractRNG,
-        M::ProductManifold,
-        pX;
-        vector_at = nothing,
-        parts_kwargs = map(_ -> (;), M.manifolds),
+        rng::AbstractRNG, M::ProductManifold, pX;
+        vector_at = nothing, parts_kwargs = map(_ -> (;), M.manifolds),
     )
     if vector_at === nothing
         map(
@@ -893,11 +869,7 @@ function retract!(M::ProductManifold, q, p, X, method::ProductRetraction)
     return q
 end
 function retract!(
-        M::ProductManifold,
-        q,
-        p,
-        X,
-        method::RTM,
+        M::ProductManifold, q, p, X, method::RTM,
     ) where {RTM <: AbstractRetractionMethod}
     map(
         (N, qc, pc, Xc) -> retract!(N, qc, pc, Xc, method),
@@ -921,12 +893,7 @@ function retract_fused!(M::ProductManifold, q, p, X, t::Number, method::ProductR
     return q
 end
 function retract_fused!(
-        M::ProductManifold,
-        q,
-        p,
-        X,
-        t::Number,
-        method::RTM,
+        M::ProductManifold, q, p, X, t::Number, method::RTM,
     ) where {RTM <: AbstractRetractionMethod}
     map(
         (N, qc, pc, Xc) -> retract_fused!(N, qc, pc, Xc, t, method),
@@ -1114,9 +1081,7 @@ end
 
 
 function Base.show(
-        io::IO,
-        mime::MIME"text/plain",
-        B::CachedBasis{𝔽, T, D},
+        io::IO, mime::MIME"text/plain", B::CachedBasis{𝔽, T, D},
     ) where {𝔽, T <: AbstractBasis{𝔽}, D <: ProductBasisData}
     println(io, "$(T) for a product manifold")
     for (i, cb) in enumerate(B.data.parts)
@@ -1150,12 +1115,7 @@ end
 submanifold(M::ProductManifold, i::AbstractVector) = submanifold(M, Val(tuple(i...)))
 
 function vector_transport_direction!(
-        M::ProductManifold,
-        Y,
-        p,
-        X,
-        d,
-        m::ProductVectorTransport,
+        M::ProductManifold, Y, p, X, d, m::ProductVectorTransport,
     )
     map(
         vector_transport_direction!,
@@ -1169,12 +1129,7 @@ function vector_transport_direction!(
     return Y
 end
 function vector_transport_direction!(
-        M::ProductManifold,
-        Y,
-        p,
-        X,
-        d,
-        m::VTM,
+        M::ProductManifold, Y, p, X, d, m::VTM,
     ) where {VTM <: AbstractVectorTransportMethod}
     map(
         (iM, iY, ip, iX, id) -> vector_transport_direction!(iM, iY, ip, iX, id, m),
@@ -1218,12 +1173,7 @@ function vector_transport_to!(M::ProductManifold, Y, p, X, q, m::ProductVectorTr
     return Y
 end
 function vector_transport_to!(
-        M::ProductManifold,
-        Y,
-        p,
-        X,
-        q,
-        m::AbstractVectorTransportMethod,
+        M::ProductManifold, Y, p, X, q, m::AbstractVectorTransportMethod,
     )
     return map(
             (iM, iY, ip, iX, iq) -> vector_transport_to!(iM, iY, ip, iX, iq, m),

--- a/src/ValidationManifold.jl
+++ b/src/ValidationManifold.jl
@@ -76,10 +76,7 @@ struct ValidationManifold{
 end
 function ValidationManifold(
         M::AbstractManifold;
-        error::Symbol = :error,
-        store_base_point::Bool = false,
-        ignore_functions::D = Dict{Function, Union{Symbol, <:Vector{Symbol}}}(),
-        ignore_contexts::V = Vector{Symbol}(),
+        error::Symbol = :error, store_base_point::Bool = false, ignore_functions::D = Dict{Function, Union{Symbol, <:Vector{Symbol}}}(), ignore_contexts::V = Vector{Symbol}(),
     ) where {
         D <: Dict{<:Function, <:Union{Symbol, <:AbstractVector{Symbol}}},
         V <: AbstractVector{Symbol},
@@ -223,16 +220,12 @@ internal_value(X::ValidationFibreVector) = X.value
 
 _update_basepoint!(::ValidationManifold, X, p) = X
 function _update_basepoint!(
-        ::ValidationManifold,
-        X::ValidationTangentVector{P, Nothing},
-        p,
+        ::ValidationManifold, X::ValidationTangentVector{P, Nothing}, p,
     ) where {P}
     return X
 end
 function _update_basepoint!(
-        M::ValidationManifold,
-        X::ValidationTangentVector{P, V},
-        p,
+        M::ValidationManifold, X::ValidationTangentVector{P, V}, p,
     ) where {P, V}
     copyto!(M.manifold, X.point, p)
     return X
@@ -246,11 +239,8 @@ end
 issue a message `str` according to the mode `mode` (as `@error`, `@warn`, `@info`).
 """
 function _msg(
-        M::ValidationManifold,
-        str;
-        error = M.mode,
-        within::Union{Nothing, <:Function} = nothing,
-        context::Union{NTuple{N, Symbol} where {N}} = NTuple{0, Symbol}(),
+        M::ValidationManifold, str;
+        error = M.mode, within::Union{Nothing, <:Function} = nothing, context::Union{NTuple{N, Symbol} where {N}} = NTuple{0, Symbol}(),
     )
     !_vMc(M, within, context) && return nothing
     (error === :error) && (throw(ErrorException(str)))
@@ -259,11 +249,8 @@ function _msg(
     return nothing
 end
 function _msg(
-        M::ValidationManifold,
-        err::Union{DomainError, ArgumentError, ErrorException};
-        error = M.mode,
-        within::Union{Nothing, <:Function} = nothing,
-        context::Union{NTuple{N, Symbol} where {N}} = NTuple{0, Symbol}(),
+        M::ValidationManifold, err::Union{DomainError, ArgumentError, ErrorException};
+        error = M.mode, within::Union{Nothing, <:Function} = nothing, context::Union{NTuple{N, Symbol} where {N}} = NTuple{0, Symbol}(),
     )
     !_vMc(M, within, context) && return nothing
     (error === :error) && (throw(err))
@@ -277,8 +264,7 @@ function convert(::Type{<:ValidationManifold{𝔽, M}}, m::M) where {𝔽, M <: 
     return ValidationManifold(m)
 end
 function convert(
-        ::Type{V},
-        p::ValidationMPoint{V},
+        ::Type{V}, p::ValidationMPoint{V},
     ) where {V <: Union{AbstractArray, AbstractManifoldPoint}}
     return p.value
 end
@@ -287,8 +273,7 @@ function convert(::Type{ValidationMPoint{V}}, x::V) where {V <: AbstractArray}
 end
 
 function convert(
-        ::Type{V},
-        X::ValidationFibreVector{TType, V, Nothing},
+        ::Type{V}, X::ValidationFibreVector{TType, V, Nothing},
     ) where {TType, V <: Union{AbstractArray, AbstractFibreVector}}
     return X.value
 end
@@ -303,10 +288,7 @@ function copyto!(M::ValidationManifold, q::ValidationMPoint, p::ValidationMPoint
     return q
 end
 function copyto!(
-        M::ValidationManifold,
-        Y::ValidationFibreVector{TType},
-        p::ValidationMPoint,
-        X::ValidationFibreVector{TType};
+        M::ValidationManifold, Y::ValidationFibreVector{TType}, p::ValidationMPoint, X::ValidationFibreVector{TType};
         kwargs...,
     ) where {TType}
     is_point(M, p; within = copyto!, context = (:Input,), kwargs...)
@@ -439,9 +421,7 @@ function get_basis(M::ValidationManifold, p, B::AbstractBasis; kwargs...)
     return Ξ
 end
 function get_basis(
-        M::ValidationManifold,
-        p,
-        B::Union{AbstractOrthogonalBasis, CachedBasis{𝔽, <:AbstractOrthogonalBasis{𝔽}} where {𝔽}};
+        M::ValidationManifold, p, B::Union{AbstractOrthogonalBasis, CachedBasis{𝔽, <:AbstractOrthogonalBasis{𝔽}} where {𝔽}};
         kwargs...,
     )
     is_point(M, p; within = get_basis, context = (:Input,), kwargs...)
@@ -466,12 +446,7 @@ function get_basis(
     return Ξ
 end
 function get_basis(
-        M::ValidationManifold,
-        p,
-        B::Union{
-            AbstractOrthonormalBasis,
-            <:CachedBasis{𝔽, <:AbstractOrthonormalBasis{𝔽}} where {𝔽},
-        };
+        M::ValidationManifold, p, B::Union{AbstractOrthonormalBasis, <:CachedBasis{𝔽, <:AbstractOrthonormalBasis{𝔽}} where {𝔽}};
         kwargs...,
     )
     is_point(M, p; within = get_basis, context = (:Input,), kwargs...)
@@ -564,9 +539,7 @@ function injectivity_radius(M::ValidationManifold, p; kwargs...)
     return injectivity_radius(M.manifold, internal_value(p))
 end
 function injectivity_radius(
-        M::ValidationManifold,
-        p,
-        method::AbstractRetractionMethod;
+        M::ValidationManifold, p, method::AbstractRetractionMethod;
         kwargs...,
     )
     is_point(M, p; within = injectivity_radius, context = (:Input,), kwargs...)
@@ -594,12 +567,8 @@ where two additional keywords can be used
 all other keywords are passed on.
 """
 function is_point(
-        M::ValidationManifold,
-        p;
-        error::Symbol = M.mode,
-        within::Union{Nothing, Function} = nothing,
-        context::NTuple{N, Symbol} where {N} = (),
-        kwargs...,
+        M::ValidationManifold, p;
+        error::Symbol = M.mode, within::Union{Nothing, Function} = nothing, context::NTuple{N, Symbol} where {N} = (), kwargs...,
     )
     !_vMc(M, within, (:Point, context...)) && return true
     return is_point(M.manifold, internal_value(p); error = error, kwargs...)
@@ -619,14 +588,8 @@ where two additional keywords can be used
 all other keywords are passed on.
 """
 function is_vector(
-        M::ValidationManifold,
-        p,
-        X,
-        cbp::Bool = true;
-        error::Symbol = M.mode,
-        within::Union{Nothing, Function} = nothing,
-        context::NTuple{N, Symbol} where {N} = (),
-        kwargs...,
+        M::ValidationManifold, p, X, cbp::Bool = true;
+        error::Symbol = M.mode, within::Union{Nothing, Function} = nothing, context::NTuple{N, Symbol} where {N} = (), kwargs...,
     )
     !_vMc(M, within, (:Vector, context...)) && return true
     return is_vector(
@@ -775,11 +738,7 @@ function show(io::IO, M::ValidationManifold)
 end
 
 function vector_transport_to(
-        M::ValidationManifold,
-        p,
-        X,
-        q,
-        m::AbstractVectorTransportMethod;
+        M::ValidationManifold, p, X, q, m::AbstractVectorTransportMethod;
         kwargs...,
     )
     is_point(M, q; within = vector_transport_to, context = (:Input,), kwargs...)
@@ -795,12 +754,7 @@ function vector_transport_to(
     return Y
 end
 function vector_transport_to!(
-        M::ValidationManifold,
-        Y,
-        p,
-        X,
-        q,
-        m::AbstractVectorTransportMethod;
+        M::ValidationManifold, Y, p, X, q, m::AbstractVectorTransportMethod;
         kwargs...,
     )
     is_point(M, q; within = vector_transport_to, context = (:Input,), kwargs...)

--- a/src/ValidationManifold.jl
+++ b/src/ValidationManifold.jl
@@ -511,7 +511,7 @@ function get_coordinates(M::ValidationManifold, p, X, B::AbstractBasis; kwargs..
         context = (:Input,),
         kwargs...,
     )
-    return get_coordinates(M.manifold, p, X, B)
+    return get_coordinates(M.manifold, internal_value(p), internal_value(X), B)
 end
 
 function get_coordinates!(M::ValidationManifold, c, p, X, B::AbstractBasis; kwargs...)
@@ -714,7 +714,7 @@ function rand(M::ValidationManifold; vector_at = nothing, kwargs...)
     if vector_at !== nothing
         is_point(M, vector_at; within = rand, context = (:Input,), kwargs...)
     end
-    pX = rand(M.manifold; vector_at = vector_at, kwargs...)
+    pX = rand(M.manifold; vector_at = internal_value(vector_at), kwargs...)
     if vector_at !== nothing
         is_vector(M, vector_at, pX; within = rand, context = (:Output,), kwargs...)
     else
@@ -827,7 +827,7 @@ end
 
 function zero_vector!(M::ValidationManifold, X, p; kwargs...)
     is_point(M, p; within = zero_vector, context = (:Input,), kwargs...)
-    zero_vector!(M.manifold, internal_value(X), internal_value(p); kwargs...)
+    zero_vector!(M.manifold, internal_value(X), internal_value(p))
     _update_basepoint!(M, X, p)
     is_vector(M, p, X; within = zero_vector, context = (:Output,), kwargs...)
     return X

--- a/src/VectorFiber.jl
+++ b/src/VectorFiber.jl
@@ -7,6 +7,8 @@ Alias for a [`Fiber`](@ref) when the fiber is a vector space.
 const VectorSpaceFiber{𝔽, M, TSpaceType} =
     Fiber{𝔽, TSpaceType, M} where {𝔽, M <: AbstractManifold, TSpaceType <: VectorSpaceType}
 
+is_flat(::VectorSpaceFiber) = true
+
 LinearAlgebra.norm(M::VectorSpaceFiber, X) = norm(M.manifold, M.point, X)
 # disambiguation
 LinearAlgebra.norm(M::VectorSpaceFiber, X::Real) = norm(M.manifold, M.point, X)

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -127,6 +127,12 @@ function DefaultOrthogonalBasis{𝔽, TangentSpaceType}() where {𝔽}
 end
 
 
+"""
+    VeeOrthogonalBasis{𝔽} <: AbstractOrthogonalBasis{𝔽,TangentSpaceType}
+
+The orthogonal basis that [`vee`](@ref) and [`hat`](@ref) use, mainly used in connection with a [`LieAlgebra`](@extref LieGroups :jl:type:`LieGroups.LieAlgebra`),
+see [`DefaultLieAlgebraOrthogonalBasis`](@extref LieGroups :jl:type:`LieGroups.DefaultLieAlgebraOrthogonalBasis`).
+"""
 struct VeeOrthogonalBasis{𝔽} <: AbstractOrthogonalBasis{𝔽, TangentSpaceType} end
 VeeOrthogonalBasis(𝔽::AbstractNumbers = ℝ) = VeeOrthogonalBasis{𝔽}()
 
@@ -327,21 +333,21 @@ allocation_promotion_function(::AbstractManifold, f, ::Tuple) = identity
 
 
 _doc_default_basis = """
-    default_basis(M::AbstractManifold, ::typeof(p); kwargs...)
+    default_basis(M::AbstractManifold, ::Type{T}; kwargs...) where {T}
     default_basis(M::AbstractManifold; kwargs...)
 
 Provide a default basis for a manifold's tangent space. This can be specific for different
-points `p` on `M`
-The global default for both is the [`DefaultOrthonormalBasis`](@ref) with
-the same number type as `M`.
+points `p` on `M`.
+The global default for both is the [`DefaultOrthonormalBasis`](@ref) with coefficients
+in the field given by the `field` keyword argument.
 
 This method can also be specified more precisely with a point type `T`, for the case
 that on a `M` there are two different representations of points, which provide
-different inverse retraction methods.
+different bases.
 
 ## Keyword arguments
 
-* `field::`[`AbstractNumbers`](@ref) field for the coefficients of the basis
+* `field::`[`AbstractNumbers`](@ref)` = ℝ`: field for the coefficients of the basis
 """
 
 @doc "$(_doc_default_basis)"
@@ -633,7 +639,7 @@ function get_coordinates!(
         Y,
         p,
         X,
-        B::AbstractBasis = DefaultOrthonormalBasis(),
+        B::AbstractBasis = default_basis(M, typeof(p)),
     )
     return _get_coordinates!(M, Y, p, X, B)
 end
@@ -777,7 +783,7 @@ end
         Y,
         p,
         c,
-        B::AbstractBasis = DefaultOrthonormalBasis(),
+        B::AbstractBasis = default_basis(M, typeof(p)),
     )
     return _get_vector!(M, Y, p, c, B)
 end
@@ -870,7 +876,8 @@ many vectors.
 Note that this method requires the manifold and basis to work on the same
 [`AbstractNumbers`](@ref) `𝔽`, i.e. with real coefficients.
 
-The method always returns a basis, i.e. linearly dependent vectors are removed.
+A vector that is linearly dependent on the previous ones stops the computation with an error,
+unless `skip_linearly_dependent` is set to `true`, in which case it is left out.
 
 # Keyword arguments
 
@@ -882,7 +889,7 @@ The method always returns a basis, i.e. linearly dependent vectors are removed.
   a basis but contains less vectors
 
 further keyword arguments can be passed to set the accuracy of the independence test.
-Especially `atol` is raised slightly by default to `atol = 5*1e-16`.
+Especially `atol` defaults to `eps(number_eltype(first(V)))`.
 
 # Return value
 

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -114,8 +114,7 @@ struct DefaultOrthogonalBasis{𝔽, VST <: VectorSpaceType} <: AbstractOrthogona
     vector_space::VST
 end
 function DefaultOrthogonalBasis(
-        𝔽::AbstractNumbers = ℝ,
-        vs::VectorSpaceType = TangentSpaceType(),
+        𝔽::AbstractNumbers = ℝ, vs::VectorSpaceType = TangentSpaceType(),
     )
     return DefaultOrthogonalBasis{𝔽, typeof(vs)}(vs)
 end
@@ -269,9 +268,7 @@ function CachedBasis(basis::CachedBasis) # avoid double encapsulation
     return basis
 end
 function CachedBasis(
-        basis::DiagonalizingOrthonormalBasis,
-        eigenvalues::ET,
-        vectors::T,
+        basis::DiagonalizingOrthonormalBasis, eigenvalues::ET, vectors::T,
     ) where {ET <: AbstractVector, T <: AbstractVector}
     data = DiagonalizingBasisData(basis.frame_direction, eigenvalues, vectors)
     return CachedBasis(basis, data)
@@ -417,16 +414,12 @@ such that ``v^i(v_j) = δ^i_j``, where ``δ^i_j`` is the Kronecker delta symbol:
 dual_basis(M::AbstractManifold, p, B::AbstractBasis) = _dual_basis(M, p, B)
 
 function _dual_basis(
-        ::AbstractManifold,
-        p,
-        ::DefaultOrthonormalBasis{𝔽, TangentSpaceType},
+        ::AbstractManifold, p, ::DefaultOrthonormalBasis{𝔽, TangentSpaceType},
     ) where {𝔽}
     return DefaultOrthonormalBasis{𝔽}(CotangentSpaceType())
 end
 function _dual_basis(
-        ::AbstractManifold,
-        p,
-        ::DefaultOrthonormalBasis{𝔽, CotangentSpaceType},
+        ::AbstractManifold, p, ::DefaultOrthonormalBasis{𝔽, CotangentSpaceType},
     ) where {𝔽}
     return DefaultOrthonormalBasis{𝔽}(TangentSpaceType())
 end
@@ -489,9 +482,7 @@ function _get_basis(M::AbstractManifold, p, B::ProjectedOrthonormalBasis{:svd, �
     return CachedBasis(B, vecs)
 end
 function _get_basis(
-        M::AbstractManifold,
-        p,
-        B::ProjectedOrthonormalBasis{:gram_schmidt, ℝ};
+        M::AbstractManifold, p, B::ProjectedOrthonormalBasis{:gram_schmidt, ℝ};
         kwargs...,
     )
     E = [project(M, p, _euclidean_basis_vector(p, i)) for i in eachindex(p)]
@@ -601,10 +592,7 @@ function _get_coordinates(M::AbstractManifold, p, X, B::DiagonalizingOrthonormal
     return get_coordinates_diagonalizing(M, p, X, B)
 end
 function get_coordinates_diagonalizing(
-        M::AbstractManifold,
-        p,
-        X,
-        B::DiagonalizingOrthonormalBasis,
+        M::AbstractManifold, p, X, B::DiagonalizingOrthonormalBasis,
     )
     c = allocate_result(M, get_coordinates, p, X, B)
     return get_coordinates_diagonalizing!(M, c, p, X, B)
@@ -614,32 +602,18 @@ function _get_coordinates(M::AbstractManifold, p, X, B::CachedBasis)
     return get_coordinates_cached(M, number_system(M), p, X, B, number_system(B))
 end
 function get_coordinates_cached(
-        M::AbstractManifold,
-        ::ComplexNumbers,
-        p,
-        X,
-        B::CachedBasis,
-        ::ComplexNumbers,
+        M::AbstractManifold, ::ComplexNumbers, p, X, B::CachedBasis, ::ComplexNumbers,
     )
     return map(vb -> conj(inner(M, p, X, vb)), get_vectors(M, p, B))
 end
 function get_coordinates_cached(
-        M::AbstractManifold,
-        ::𝔽,
-        p,
-        X,
-        C::CachedBasis,
-        ::RealNumbers,
+        M::AbstractManifold, ::𝔽, p, X, C::CachedBasis, ::RealNumbers,
     ) where {𝔽}
     return map(vb -> real(inner(M, p, X, vb)), get_vectors(M, p, C))
 end
 
 function get_coordinates!(
-        M::AbstractManifold,
-        Y,
-        p,
-        X,
-        B::AbstractBasis = default_basis(M, typeof(p)),
+        M::AbstractManifold, Y, p, X, B::AbstractBasis = default_basis(M, typeof(p)),
     )
     return _get_coordinates!(M, Y, p, X, B)
 end
@@ -746,10 +720,7 @@ end
     return get_vector_diagonalizing(M, p, c, B)
 end
 function get_vector_diagonalizing(
-        M::AbstractManifold,
-        p,
-        c,
-        B::DiagonalizingOrthonormalBasis,
+        M::AbstractManifold, p, c, B::DiagonalizingOrthonormalBasis,
     )
     Y = allocate_result(M, get_vector, p, c)
     return get_vector!(M, Y, p, c, B)
@@ -898,8 +869,7 @@ When an [`AbstractBasis`](@ref) is orthonormalized, a [`CachedBasis`](@ref) is r
 """
 function gram_schmidt(
         M::AbstractManifold{𝔽}, p, B::AbstractBasis{𝔽};
-        warn_linearly_dependent = false, return_incomplete_set = false, skip_linearly_dependent = false,
-        kwargs...,
+        warn_linearly_dependent = false, return_incomplete_set = false, skip_linearly_dependent = false, kwargs...,
     ) where {𝔽}
     V = gram_schmidt(
         M, p, get_vectors(M, p, B);
@@ -910,9 +880,7 @@ function gram_schmidt(
 end
 function gram_schmidt(
         M::AbstractManifold, p, V::AbstractVector;
-        atol = eps(number_eltype(first(V))), warn_linearly_dependent = false,
-        return_incomplete_set = false, skip_linearly_dependent = false,
-        kwargs...,
+        atol = eps(number_eltype(first(V))), warn_linearly_dependent = false, return_incomplete_set = false, skip_linearly_dependent = false, kwargs...,
     )
     N = length(V)
     Ξ = empty(V)
@@ -1051,9 +1019,7 @@ function show(io::IO, ::MIME"text/plain", onb::DiagonalizingOrthonormalBasis)
     return print(io, sk)
 end
 function show(
-        io::IO,
-        ::MIME"text/plain",
-        B::CachedBasis{𝔽, T, D},
+        io::IO, ::MIME"text/plain", B::CachedBasis{𝔽, T, D},
     ) where {𝔽, T <: AbstractBasis, D}
     try
         vectors = _get_vectors(B)
@@ -1074,9 +1040,7 @@ function show(
     end
 end
 function show(
-        io::IO,
-        ::MIME"text/plain",
-        B::CachedBasis{𝔽, T, D},
+        io::IO, ::MIME"text/plain", B::CachedBasis{𝔽, T, D},
     ) where {𝔽, T <: DiagonalizingOrthonormalBasis, D <: DiagonalizingBasisData}
     vectors = _get_vectors(B)
     nv = length(vectors)

--- a/src/bases.jl
+++ b/src/bases.jl
@@ -575,7 +575,10 @@ function _get_coordinates(M::AbstractManifold, p, X, B::DefaultOrthogonalBasis)
     return get_coordinates_orthogonal(M, p, X, number_system(B))
 end
 function get_coordinates_orthogonal(M::AbstractManifold, p, X, N)
-    return get_coordinates_orthonormal(M, p, X, N)
+    # arguments X and p for allocate_result are intentionally reversed
+    # to make ManifoldDiff.jl tests pass
+    c = allocate_result(M, get_coordinates, X, p, DefaultOrthogonalBasis(N))
+    return get_coordinates_orthogonal!(M, c, p, X, N)
 end
 
 function _get_coordinates(M::AbstractManifold, p, X, B::DefaultOrthonormalBasis)
@@ -720,7 +723,8 @@ end
     return get_vector_orthogonal(M, p, c, number_system(B))
 end
 @inline function get_vector_orthogonal(M::AbstractManifold, p, c, N)
-    return get_vector_orthonormal(M, p, c, N)
+    Y = allocate_result(M, get_vector, p, c)
+    return get_vector_orthogonal!(M, Y, p, c, N)
 end
 
 function _get_vector(M::AbstractManifold, p, c, B::DefaultOrthonormalBasis)

--- a/src/connection.jl
+++ b/src/connection.jl
@@ -74,7 +74,7 @@ is_default_connection(M::AbstractManifold, c::AbstractAffineConnection)
 function is_default_connection(M::AbstractManifold, c::AbstractAffineConnection)
     return connection(M) == c
 end
-is_default_connection(M::ConnectionManifold) = true
+is_default_connection(M::ConnectionManifold) = connection(M.manifold) === M.connection
 
 manifold_dimension(M::ConnectionManifold) = manifold_dimension(M.manifold)
 

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -265,17 +265,13 @@ end
 )
 
 function allocate_result_embedding(
-        M::AbstractManifold,
-        f::typeof(embed),
-        x::Vararg{Any, N},
+        M::AbstractManifold, f::typeof(embed), x::Vararg{Any, N},
     ) where {N}
     T = allocate_result_type(get_embedding(M, typeof(x[end])), f, x)
     return allocate(M, x[1], T, representation_size(get_embedding(M, typeof(x[end]))))
 end
 function allocate_result_embedding(
-        M::AbstractManifold,
-        f::typeof(project),
-        x::Vararg{Any, N},
+        M::AbstractManifold, f::typeof(project), x::Vararg{Any, N},
     ) where {N}
     T = allocate_result_type(M, f, x)
     return allocate(M, x[1], T, representation_size(M))
@@ -286,17 +282,10 @@ end
 @trait_function change_metric!(M::AbstractDecoratorManifold, Y, G::AbstractMetric, X, p)
 
 @trait_function change_representer(
-    M::AbstractDecoratorManifold,
-    G::AbstractMetric,
-    X,
-    p,
+    M::AbstractDecoratorManifold, G::AbstractMetric, X, p,
 )
 @trait_function change_representer!(
-    M::AbstractDecoratorManifold,
-    Y,
-    G::AbstractMetric,
-    X,
-    p,
+    M::AbstractDecoratorManifold, Y, G::AbstractMetric, X, p,
 )
 
 @trait_function check_size(M::AbstractDecoratorManifold, p) (
@@ -313,9 +302,7 @@ function _check_size_forwarding(::EmbeddedForwardingType, M::AbstractDecoratorMa
     return nothing
 end
 function _check_size_forwarding(
-        ::EmbeddedForwardingType{DirectEmbedding},
-        M::AbstractDecoratorManifold,
-        p,
+        ::EmbeddedForwardingType{DirectEmbedding}, M::AbstractDecoratorManifold, p,
     )
     mpe = check_size(get_embedding(M, typeof(p)), p)
     if mpe !== nothing
@@ -331,10 +318,7 @@ end
     StopForwardingType,
 )
 function _check_size_forwarding(
-        ::EmbeddedForwardingType,
-        M::AbstractDecoratorManifold,
-        p,
-        X,
+        ::EmbeddedForwardingType, M::AbstractDecoratorManifold, p, X,
     )
     mpe = check_size(get_embedding(M, typeof(p)), embed(M, p), embed(M, p, X))
     if mpe !== nothing
@@ -346,10 +330,7 @@ function _check_size_forwarding(
     return nothing
 end
 function _check_size_forwarding(
-        ::EmbeddedForwardingType{DirectEmbedding},
-        M::AbstractDecoratorManifold,
-        p,
-        X,
+        ::EmbeddedForwardingType{DirectEmbedding}, M::AbstractDecoratorManifold, p, X,
     )
     mpe = check_size(get_embedding(M, typeof(p)), p, X)
     if mpe !== nothing
@@ -368,11 +349,7 @@ function _copyto!_forwarding(::EmbeddedForwardingType, M::AbstractDecoratorManif
     return copyto!(get_embedding(M, typeof(p)), q, p)
 end
 function _copyto!_forwarding(
-        ::EmbeddedForwardingType,
-        M::AbstractDecoratorManifold,
-        Y,
-        p,
-        X,
+        ::EmbeddedForwardingType, M::AbstractDecoratorManifold, Y, p, X,
     )
     return copyto!(get_embedding(M, typeof(p)), Y, p, X)
 end
@@ -507,14 +484,8 @@ end
 )
 
 function _is_point_forwarding(
-        T::Union{
-            EmbeddedForwardingType{D},
-            IsometricallyEmbeddedManifoldType{D},
-        },
-        M::AbstractDecoratorManifold,
-        p;
-        error::Symbol = :none,
-        kwargs...,
+        T::Union{EmbeddedForwardingType{D}, IsometricallyEmbeddedManifoldType{D}}, M::AbstractDecoratorManifold, p;
+        error::Symbol = :none, kwargs...,
     ) where {D <: AbstractEmbeddingDirectness}
     # to be safe check_size first
     es = check_size(M, p)
@@ -564,16 +535,8 @@ end
 ) (StopForwardingType, SimpleForwardingType)
 
 function _is_vector_forwarding(
-        T::Union{
-            EmbeddedForwardingType{D},
-            IsometricallyEmbeddedManifoldType{D},
-        },
-        M::AbstractDecoratorManifold,
-        p,
-        X,
-        check_base_point::Bool = true;
-        error::Symbol = :none,
-        kwargs...,
+        T::Union{EmbeddedForwardingType{D}, IsometricallyEmbeddedManifoldType{D}}, M::AbstractDecoratorManifold, p, X, check_base_point::Bool = true;
+        error::Symbol = :none, kwargs...,
     ) where {D <: AbstractEmbeddingDirectness}
     es = check_size(M, p, X)
     if es !== nothing
@@ -647,20 +610,13 @@ end
 @trait_function _isapprox(M::AbstractDecoratorManifold, p, X, Y; kwargs...)
 
 function __isapprox_forwarding(
-        ::EmbeddedForwardingType,
-        M::AbstractDecoratorManifold,
-        p,
-        q;
+        ::EmbeddedForwardingType, M::AbstractDecoratorManifold, p, q;
         kwargs...,
     )
     return _isapprox(get_embedding(M, typeof(p)), embed(M, p), embed(M, q); kwargs...)
 end
 function __isapprox_forwarding(
-        ::EmbeddedForwardingType,
-        M::AbstractDecoratorManifold,
-        p,
-        X,
-        Y;
+        ::EmbeddedForwardingType, M::AbstractDecoratorManifold, p, X, Y;
         kwargs...,
     )
     return _isapprox(
@@ -861,12 +817,7 @@ function get_forwarding_type(M::AbstractDecoratorManifold, f, P::Type)
 end
 
 function get_forwarding_type_embedding(
-        ::Union{
-            EmbeddedManifoldType, IsometricallyEmbeddedManifoldType, EmbeddedSubmanifoldType,
-            NotEmbeddedManifoldType,
-        },
-        M::AbstractDecoratorManifold,
-        f,
+        ::Union{EmbeddedManifoldType, IsometricallyEmbeddedManifoldType, EmbeddedSubmanifoldType, NotEmbeddedManifoldType}, M::AbstractDecoratorManifold, f,
     )
     return StopForwardingType()
 end
@@ -878,14 +829,12 @@ for mf in vcat(
     )
     @eval begin
         function get_forwarding_type_embedding(
-                ::EmbeddedSubmanifoldType{DirectEmbedding},
-                M::AbstractDecoratorManifold, ::typeof($mf),
+                ::EmbeddedSubmanifoldType{DirectEmbedding}, M::AbstractDecoratorManifold, ::typeof($mf),
             )
             return EmbeddedForwardingType(DirectEmbedding())
         end
         function get_forwarding_type_embedding(
-                ::EmbeddedSubmanifoldType{IndirectEmbedding},
-                M::AbstractDecoratorManifold, ::typeof($mf),
+                ::EmbeddedSubmanifoldType{IndirectEmbedding}, M::AbstractDecoratorManifold, ::typeof($mf),
             )
             return EmbeddedForwardingType(IndirectEmbedding())
         end
@@ -895,14 +844,12 @@ end
 for mf in vcat(forward_functions_isometric, forward_functions_embedded)
     @eval begin
         function get_forwarding_type_embedding(
-                ::IsometricallyEmbeddedManifoldType{DirectEmbedding},
-                M::AbstractDecoratorManifold, ::typeof($mf),
+                ::IsometricallyEmbeddedManifoldType{DirectEmbedding}, M::AbstractDecoratorManifold, ::typeof($mf),
             )
             return EmbeddedForwardingType(DirectEmbedding())
         end
         function get_forwarding_type_embedding(
-                ::IsometricallyEmbeddedManifoldType{IndirectEmbedding},
-                M::AbstractDecoratorManifold, ::typeof($mf),
+                ::IsometricallyEmbeddedManifoldType{IndirectEmbedding}, M::AbstractDecoratorManifold, ::typeof($mf),
             )
             return EmbeddedForwardingType(IndirectEmbedding())
         end
@@ -912,14 +859,12 @@ end
 for mf in forward_functions_embedded
     @eval begin
         function get_forwarding_type_embedding(
-                ::EmbeddedManifoldType{DirectEmbedding},
-                M::AbstractDecoratorManifold, ::typeof($mf),
+                ::EmbeddedManifoldType{DirectEmbedding}, M::AbstractDecoratorManifold, ::typeof($mf),
             )
             return EmbeddedForwardingType(DirectEmbedding())
         end
         function get_forwarding_type_embedding(
-                ::EmbeddedManifoldType{IndirectEmbedding},
-                M::AbstractDecoratorManifold, ::typeof($mf),
+                ::EmbeddedManifoldType{IndirectEmbedding}, M::AbstractDecoratorManifold, ::typeof($mf),
             )
             return EmbeddedForwardingType(IndirectEmbedding())
         end

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -118,9 +118,7 @@ A property of an embedded manifold that indicates that `embed` and `project` are
 """
 struct EmbeddedManifoldType{EN <: AbstractEmbeddingDirectness} <: AbstractEmbeddingType end
 
-function EmbeddedManifoldType(en::AbstractEmbeddingDirectness = IndirectEmbedding())
-    return EmbeddedManifoldType{typeof(en)}()
-end
+EmbeddedManifoldType(::EN = DirectEmbedding()) where {EN <: AbstractEmbeddingDirectness} = EmbeddedManifoldType{EN}()
 
 """
     IsometricallyEmbeddedManifold <: AbstractEmbeddingType
@@ -132,11 +130,7 @@ Here, additionally, metric related functions like [`inner`](@ref) and [`norm`](@
 """
 struct IsometricallyEmbeddedManifoldType{EN <: AbstractEmbeddingDirectness} <: AbstractEmbeddingType end
 
-function IsometricallyEmbeddedManifoldType(
-        en::AbstractEmbeddingDirectness = IndirectEmbedding(),
-    )
-    return IsometricallyEmbeddedManifoldType{typeof(en)}()
-end
+IsometricallyEmbeddedManifoldType(::EN = DirectEmbedding()) where {EN <: AbstractEmbeddingDirectness} = IsometricallyEmbeddedManifoldType{EN}()
 
 """
     EmbeddedSubmanifoldType <: AbstractEmbeddingType
@@ -151,9 +145,7 @@ are passed to the embedding.
 """
 struct EmbeddedSubmanifoldType{EN <: AbstractEmbeddingDirectness} <: AbstractEmbeddingType end
 
-function EmbeddedSubmanifoldType(en::AbstractEmbeddingDirectness = IndirectEmbedding())
-    return EmbeddedSubmanifoldType{typeof(en)}()
-end
+EmbeddedSubmanifoldType(::EN = DirectEmbedding()) where {EN <: AbstractEmbeddingDirectness} = EmbeddedSubmanifoldType{EN}()
 
 _doc_get_embedding_type = """
     get_embedding_type(M::AbstractManifold)
@@ -889,13 +881,13 @@ for mf in vcat(
                 ::EmbeddedSubmanifoldType{DirectEmbedding},
                 M::AbstractDecoratorManifold, ::typeof($mf),
             )
-            return EmbeddedForwardingType()
+            return EmbeddedForwardingType(DirectEmbedding())
         end
         function get_forwarding_type_embedding(
                 ::EmbeddedSubmanifoldType{IndirectEmbedding},
                 M::AbstractDecoratorManifold, ::typeof($mf),
             )
-            return EmbeddedForwardingType(DirectEmbedding())
+            return EmbeddedForwardingType(IndirectEmbedding())
         end
     end
 end
@@ -906,13 +898,13 @@ for mf in vcat(forward_functions_isometric, forward_functions_embedded)
                 ::IsometricallyEmbeddedManifoldType{DirectEmbedding},
                 M::AbstractDecoratorManifold, ::typeof($mf),
             )
-            return EmbeddedForwardingType()
+            return EmbeddedForwardingType(DirectEmbedding())
         end
         function get_forwarding_type_embedding(
                 ::IsometricallyEmbeddedManifoldType{IndirectEmbedding},
                 M::AbstractDecoratorManifold, ::typeof($mf),
             )
-            return EmbeddedForwardingType(DirectEmbedding())
+            return EmbeddedForwardingType(IndirectEmbedding())
         end
     end
 end
@@ -923,13 +915,13 @@ for mf in forward_functions_embedded
                 ::EmbeddedManifoldType{DirectEmbedding},
                 M::AbstractDecoratorManifold, ::typeof($mf),
             )
-            return EmbeddedForwardingType()
+            return EmbeddedForwardingType(DirectEmbedding())
         end
         function get_forwarding_type_embedding(
                 ::EmbeddedManifoldType{IndirectEmbedding},
                 M::AbstractDecoratorManifold, ::typeof($mf),
             )
-            return EmbeddedForwardingType(DirectEmbedding())
+            return EmbeddedForwardingType(IndirectEmbedding())
         end
     end
 end

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -1,7 +1,12 @@
 #
 # Base pass-ons
 #
-manifold_dimension(M::AbstractDecoratorManifold) = manifold_dimension(base_manifold(M))
+function manifold_dimension(M::AbstractDecoratorManifold)
+    N = base_manifold(M)
+    # nothing was decorated, so there is nothing to pass this on to
+    (N === M) && throw(MethodError(manifold_dimension, (M,)))
+    return manifold_dimension(N)
+end
 
 #
 # Forwarding types

--- a/src/decorator_trait.jl
+++ b/src/decorator_trait.jl
@@ -272,8 +272,8 @@ function allocate_result_embedding(
         f::typeof(embed),
         x::Vararg{Any, N},
     ) where {N}
-    T = allocate_result_type(get_embedding(M, typeof(x[1])), f, x)
-    return allocate(M, x[1], T, representation_size(get_embedding(M, typeof(x[1]))))
+    T = allocate_result_type(get_embedding(M, typeof(x[end])), f, x)
+    return allocate(M, x[1], T, representation_size(get_embedding(M, typeof(x[end]))))
 end
 function allocate_result_embedding(
         M::AbstractManifold,

--- a/src/metric.jl
+++ b/src/metric.jl
@@ -143,16 +143,12 @@ function Base.convert(::Type{MetricManifold{𝔽, MT, GT}}, M::MT) where {𝔽, 
 end
 
 function _convert_with_default(
-        M::MT,
-        T::Type{<:AbstractMetric},
-        ::Val{true},
+        M::MT, T::Type{<:AbstractMetric}, ::Val{true},
     ) where {MT <: AbstractManifold}
     return MetricManifold(M, T())
 end
 function _convert_with_default(
-        M::MT,
-        T::Type{<:AbstractMetric},
-        ::Val{false},
+        M::MT, T::Type{<:AbstractMetric}, ::Val{false},
     ) where {MT <: AbstractManifold}
     return error(
         "Can not convert $(M) to a MetricManifold{$(MT),$(T)}, since $(T) is not the default metric.",
@@ -455,8 +451,7 @@ Therefore, this method only falls back to calling its corresponding method on th
 vector_transport_direction(::MetricManifold, ::Any, ::Any, ::Any)
 
 function vector_transport_direction(
-        M::MetricManifold, p, X, d,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::MetricManifold, p, X, d, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     (metric(M.manifold) === M.metric) && (return vector_transport_direction(M.manifold, p, X, d, m))
     return invoke(
@@ -466,8 +461,7 @@ function vector_transport_direction(
     )
 end
 function vector_transport_direction!(
-        M::MetricManifold, Y, p, X, d,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::MetricManifold, Y, p, X, d, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     (metric(M.manifold) === M.metric) && (return vector_transport_direction!(M.manifold, Y, p, X, d, m))
     return invoke(
@@ -490,11 +484,7 @@ Therefore, this method only falls back to calling its corresponding method on th
 vector_transport_to(::MetricManifold, ::Any, ::Any, ::Any)
 
 function vector_transport_to(
-        M::MetricManifold,
-        p,
-        X,
-        q,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::MetricManifold, p, X, q, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     (metric(M.manifold) === M.metric) && (return vector_transport_to(M.manifold, p, X, q, m))
     return invoke(
@@ -504,8 +494,7 @@ function vector_transport_to(
     )
 end
 function vector_transport_to!(
-        M::MetricManifold, Y, p, X, q,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::MetricManifold, Y, p, X, q, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     (metric(M.manifold) === M.metric) && (return vector_transport_to!(M.manifold, Y, p, X, q, m))
     return invoke(

--- a/src/numerical_checks.jl
+++ b/src/numerical_checks.jl
@@ -47,21 +47,8 @@ the plot is generated first and returned (to be shown/displayed), such that no e
 You can switch to e.g. `:warn` to get a warning together with the plot.
 """
 function check_inverse_retraction(
-        M::AbstractManifold,
-        inverse_retraction_method::AbstractInverseRetractionMethod,
-        p = rand(M),
-        X = rand(M; vector_at = p);
-        exactness_tol::Real = 1.0e-12,
-        io::Union{IO, Nothing} = nothing,
-        limits = (-8.0, 0.0),
-        N::Int = 101,
-        second_order::Bool = true,
-        name::String = second_order ? "second order inverse retraction" : "inverse retraction",
-        log_range::AbstractVector = range(limits[1], limits[2]; length = N),
-        plot::Bool = false,
-        slope_tol::Real = 0.1,
-        error::Symbol = :none,
-        window = nothing,
+        M::AbstractManifold, inverse_retraction_method::AbstractInverseRetractionMethod, p = rand(M), X = rand(M; vector_at = p);
+        exactness_tol::Real = 1.0e-12, io::Union{IO, Nothing} = nothing, limits = (-8.0, 0.0), N::Int = 101, second_order::Bool = true, name::String = second_order ? "second order inverse retraction" : "inverse retraction", log_range::AbstractVector = range(limits[1], limits[2]; length = N), plot::Bool = false, slope_tol::Real = 0.1, error::Symbol = :none, window = nothing,
     )
     Xn = X ./ norm(M, p, X) # normalize tangent direction
     # function for the directional derivative
@@ -145,10 +132,7 @@ You can switch to e.g. `:warn` to get a warning together with the plot.
 """
 function check_geodesic(
         M::AbstractManifold, p = rand(M), X = rand(M; vector_at = p);
-        error::Symbol = :none, io::Union{IO, Nothing} = nothing,
-        N::Int = 101, tol::Real = 1.0e-12, plot::Bool = false,
-        inverse_retraction_method::AbstractInverseRetractionMethod = LogarithmicInverseRetraction(),
-        vector_transport_method::AbstractVectorTransportMethod = ParallelTransport(),
+        error::Symbol = :none, io::Union{IO, Nothing} = nothing, N::Int = 101, tol::Real = 1.0e-12, plot::Bool = false, inverse_retraction_method::AbstractInverseRetractionMethod = LogarithmicInverseRetraction(), vector_transport_method::AbstractVectorTransportMethod = ParallelTransport(),
     )
     T = range(0.0, 1.0; length = N)
     γ = geodesic(M, p, X)
@@ -236,14 +220,8 @@ the plot is generated first and returned (to be shown/displayed), such that no e
 You can switch to e.g. `:warn` to get a warning together with the plot.
 """
 function check_retraction(
-        M::AbstractManifold, retraction_method::AbstractRetractionMethod,
-        p = rand(M), X = rand(M; vector_at = p);
-        error::Symbol = :none, exactness_tol::Real = 1.0e-12,
-        io::Union{IO, Nothing} = nothing, limits::Tuple = (-8.0, 0.0), N::Int = 101,
-        second_order::Bool = true,
-        name::String = second_order ? "second order retraction" : "retraction",
-        log_range = range(limits[1], limits[2]; length = N),
-        plot::Bool = false, slope_tol::Real = 0.1, window = nothing,
+        M::AbstractManifold, retraction_method::AbstractRetractionMethod, p = rand(M), X = rand(M; vector_at = p);
+        error::Symbol = :none, exactness_tol::Real = 1.0e-12, io::Union{IO, Nothing} = nothing, limits::Tuple = (-8.0, 0.0), N::Int = 101, second_order::Bool = true, name::String = second_order ? "second order retraction" : "retraction", log_range = range(limits[1], limits[2]; length = N), plot::Bool = false, slope_tol::Real = 0.1, window = nothing,
     )
     Xn = X ./ norm(M, p, X) # normalize tangent direction
     # function for the directional derivative
@@ -313,16 +291,8 @@ the plot is generated first and returned (to be shown/displayed), such that no e
 You can switch to e.g. `:warn` to get a warning together with the plot.
 """
 function check_vector_transport(
-        M::AbstractManifold, vector_transport_method::AbstractVectorTransportMethod,
-        p = rand(M), X = rand(M; vector_at = p), Y = rand(M; vector_at = p);
-        error::Symbol = :none, exactness_tol::Real = 1.0e-12,
-        io::Union{IO, Nothing} = nothing,
-        limits::Tuple = (-8.0, 0.0),
-        N::Int = 101,
-        log_range::AbstractVector = range(limits[1], limits[2]; length = N),
-        second_order::Bool = true,
-        name::String = second_order ? "second order vector transport" : "vector transport",
-        plot::Bool = false, slope_tol::Real = 0.1, window = nothing,
+        M::AbstractManifold, vector_transport_method::AbstractVectorTransportMethod, p = rand(M), X = rand(M; vector_at = p), Y = rand(M; vector_at = p);
+        error::Symbol = :none, exactness_tol::Real = 1.0e-12, io::Union{IO, Nothing} = nothing, limits::Tuple = (-8.0, 0.0), N::Int = 101, log_range::AbstractVector = range(limits[1], limits[2]; length = N), second_order::Bool = true, name::String = second_order ? "second order vector transport" : "vector transport", plot::Bool = false, slope_tol::Real = 0.1, window = nothing,
     )
     Xn = X ./ norm(M, p, X) # normalize tangent direction
     # function for the directional derivative
@@ -394,9 +364,7 @@ You you can switch to e.g. `:warn` to get a warning together with the plot.
 """
 function prepare_check_result(
         log_range::AbstractVector, errors::AbstractVector, slope::Real;
-        error::Symbol = :none, exactness_tol::Real = 1.0e3 * eps(eltype(errors)),
-        io::Union{IO, Nothing} = nothing, name::String = "estimated slope",
-        plot::Bool = false, slope_tol::Real = 1.0e-1, window = nothing,
+        error::Symbol = :none, exactness_tol::Real = 1.0e3 * eps(eltype(errors)), io::Union{IO, Nothing} = nothing, name::String = "estimated slope", plot::Bool = false, slope_tol::Real = 1.0e-1, window = nothing,
     )
     if max(errors...) < exactness_tol
         (io !== nothing) && print(

--- a/src/parallel_transport.jl
+++ b/src/parallel_transport.jl
@@ -1,3 +1,9 @@
+@doc raw"""
+    parallel_transport_direction!(M::AbstractManifold, Y, p, X, d)
+
+Compute the parallel transport of ``X`` along the curve ``c(t) = γ_{p,d}(t)`` to ``c(1)=q``
+in-place of `Y`, see [`parallel_transport_direction`](@ref).
+"""
 function parallel_transport_direction!(M::AbstractManifold, Y, p, X, d; kwargs...)
     return parallel_transport_to!(M, Y, p, X, exp(M, p, d); kwargs...)
 end
@@ -5,16 +11,22 @@ end
 @doc raw"""
     parallel_transport_direction(M::AbstractManifold, p, X, d)
 
-Compute the parallel transport of ``X`` along the curve ``c(t) = γ_{p,X}(t)`` to ``c(1)=q``,
-where ``c(t)=γ_{p,X}(t)`` is the the unique geodesic starting from ``γ_{p,d}(0)=p``
-into direction ``̇\dot γ_{p,d}(0)=d``.
+Compute the parallel transport of ``X`` along the curve ``c(t) = γ_{p,d}(t)`` to ``c(1)=q``,
+where ``c(t)=γ_{p,d}(t)`` is the unique geodesic starting from ``γ_{p,d}(0)=p``
+into direction ``\dot γ_{p,d}(0)=d``.
 
-By default this function calls [`parallel_transport_to`](@ref)`(M, p, X, q)`, where ``q=\exp_pX``.
+By default this function calls [`parallel_transport_to`](@ref)`(M, p, X, q)`, where ``q=\exp_p d``.
 """
 function parallel_transport_direction(M::AbstractManifold, p, X, d; kwargs...)
     return parallel_transport_to(M, p, X, exp(M, p, d); kwargs...)
 end
 
+@doc raw"""
+    parallel_transport_to!(M::AbstractManifold, Y, p, X, q)
+
+Compute the parallel transport of ``X`` along the curve ``c(t) = γ_{p,q}(t)`` in-place of `Y`,
+see [`parallel_transport_to`](@ref).
+"""
 function parallel_transport_to! end
 
 @doc raw"""

--- a/src/point_vector_fallbacks.jl
+++ b/src/point_vector_fallbacks.jl
@@ -97,13 +97,13 @@ points of type `TP`, tangent vectors of type `TV`, with forwarding to fields `pf
 macro default_manifold_fallbacks(TM, TP, TV, pfield::Symbol, vfield::Symbol)
     block = quote
         function ManifoldsBase.allocate_result(::$TM, ::typeof(log), p::$TP, ::$TP)
-            a = allocate(p.$vfield)
+            a = allocate(p.$pfield)
             return $TV(a)
         end
         function ManifoldsBase.allocate_result(
                 ::$TM, ::typeof(inverse_retract), p::$TP, ::$TP,
             )
-            a = allocate(p.$vfield)
+            a = allocate(p.$pfield)
             return $TV(a)
         end
         function ManifoldsBase.allocate_coordinates(M::$TM, p::$TP, T, n::Int)
@@ -358,14 +358,28 @@ macro default_manifold_fallbacks(TM, TP, TV, pfield::Symbol, vfield::Symbol)
     )
     # forward vector transports
 
-    for sub in [:project, :diff, :embedded]
-        # project & diff
+    push!(
+        block.args,
+        quote
+            function ManifoldsBase.vector_transport_to_project!(
+                    M::$TM, Y::$TV, p::$TP, X::$TV, q::$TP,
+                )
+                ManifoldsBase.vector_transport_to_project!(
+                    M, Y.$vfield, p.$pfield, X.$vfield, q.$pfield,
+                )
+                return Y
+            end
+        end,
+    )
+    for sub in [:diff, :embedded]
         vttm = Symbol("vector_transport_to_$(sub)!")
         push!(
             block.args,
             quote
-                function ManifoldsBase.$vttm(M::$TM, Y::$TV, p::$TP, X::$TV, q::$TP)
-                    ManifoldsBase.$vttm(M, Y.$vfield, p.$pfield, X.$vfield, q.$pfield)
+                function ManifoldsBase.$vttm(M::$TM, Y::$TV, p::$TP, X::$TV, q::$TP, m)
+                    ManifoldsBase.$vttm(
+                        M, Y.$vfield, p.$pfield, X.$vfield, q.$pfield, m,
+                    )
                     return Y
                 end
             end,

--- a/src/point_vector_fallbacks.jl
+++ b/src/point_vector_fallbacks.jl
@@ -65,9 +65,7 @@ macro manifold_element_forwards(T, Twhere, field::Symbol)
                     return $T(allocate(p.$field, P))
                 end
                 function ManifoldsBase.allocate(
-                        p::$T,
-                        ::Type{P},
-                        dims::Tuple,
+                        p::$T, ::Type{P}, dims::Tuple,
                     ) where {P, $Twhere}
                     return $T(allocate(p.$field, P, dims))
                 end
@@ -502,8 +500,7 @@ macro manifold_vector_forwards(T, Twhere, field::Symbol)
                 end
 
                 function Broadcast.BroadcastStyle(
-                        ::Broadcast.AbstractArrayStyle{0},
-                        b::Broadcast.Style{$T},
+                        ::Broadcast.AbstractArrayStyle{0}, b::Broadcast.Style{$T},
                     )
                     return b
                 end
@@ -551,8 +548,7 @@ macro manifold_vector_forwards(T, Twhere, field::Symbol)
                 end
 
                 function Broadcast.BroadcastStyle(
-                        ::Broadcast.AbstractArrayStyle{0},
-                        b::Broadcast.Style{$T},
+                        ::Broadcast.AbstractArrayStyle{0}, b::Broadcast.Style{$T},
                     ) where {$Twhere}
                     return b
                 end

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -492,9 +492,8 @@ corresponding manifold.
 See also [`retract`](@ref).
 """
 function inverse_retract(
-        M::AbstractManifold, p, q,
-        m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p));
-        kwargs...
+        M::AbstractManifold, p, q, m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p));
+        kwargs...,
     )
     return _inverse_retract(M, p, q, m; kwargs...)
 end
@@ -520,9 +519,8 @@ available methods.
 See also [`retract!`](@ref).
 """
 function inverse_retract!(
-        M::AbstractManifold, X, p, q,
-        m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p));
-        kwargs...
+        M::AbstractManifold, X, p, q, m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p));
+        kwargs...,
     )
     return _inverse_retract!(M, X, p, q, m; kwargs...)
 end
@@ -712,9 +710,8 @@ Locally, the retraction is invertible. For the inverse operation, see [`inverse_
 
 @doc "$(_doc_retract)"
 function retract(
-        M::AbstractManifold, p, X,
-        m::AbstractRetractionMethod = default_retraction_method(M, typeof(p));
-        kwargs...
+        M::AbstractManifold, p, X, m::AbstractRetractionMethod = default_retraction_method(M, typeof(p));
+        kwargs...,
     )
     return _retract(M, p, X, m; kwargs...)
 end
@@ -729,9 +726,8 @@ end
 
 @doc "$(_doc_retract)"
 function retract!(
-        M::AbstractManifold, q, p, X,
-        method::AbstractRetractionMethod = default_retraction_method(M, typeof(p));
-        kwargs...
+        M::AbstractManifold, q, p, X, method::AbstractRetractionMethod = default_retraction_method(M, typeof(p));
+        kwargs...,
     )
     return _retract!(M, q, p, X, method; kwargs...)
 end
@@ -798,9 +794,8 @@ By default, this falls back to calling [`retract`](@ref) with `t*X`.
 
 @doc "$(_doc_retract_fused)"
 function retract_fused(
-        M::AbstractManifold, p, X, t::Number,
-        m::AbstractRetractionMethod = default_retraction_method(M, typeof(p));
-        kwargs...
+        M::AbstractManifold, p, X, t::Number, m::AbstractRetractionMethod = default_retraction_method(M, typeof(p));
+        kwargs...,
     )
     return _retract_fused(M, p, X, t, m; kwargs...)
 end
@@ -815,9 +810,8 @@ end
 
 @doc "$(_doc_retract_fused)"
 function retract_fused!(
-        M::AbstractManifold, q, p, X, t::Number,
-        m::AbstractRetractionMethod = default_retraction_method(M, typeof(p));
-        kwargs...
+        M::AbstractManifold, q, p, X, t::Number, m::AbstractRetractionMethod = default_retraction_method(M, typeof(p));
+        kwargs...,
     )
     return _retract_fused!(M, q, p, X, t, m; kwargs...)
 end

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -363,7 +363,7 @@ struct NLSolveInverseRetraction{TR <: AbstractRetractionMethod, TV, TK} <:
     nlsolve_kwargs::TK
     function NLSolveInverseRetraction(m, X0, project_point, project_tangent, nlsolve_kwargs)
         return new{typeof(m), typeof(X0), typeof(nlsolve_kwargs)}(
-            m, X0, project_point, project_tangent, nlsolve_kwargs,
+            m, X0, project_tangent, project_point, nlsolve_kwargs,
         )
     end
 end
@@ -608,7 +608,7 @@ function inverse_retract_embedded!(
     return project!(
         M, X, p,
         inverse_retract(
-            get_embedding(M, P), embed(get_embedding(M, P), p), embed(get_embedding(M, P), q), m,
+            get_embedding(M, P), embed(M, p), embed(M, q), m,
         ),
     )
 end
@@ -903,7 +903,7 @@ function retract_embedded!(
         M,
         q,
         retract(
-            get_embedding(M, P), embed(get_embedding(M, P), p), embed(get_embedding(M, P), p, X), m;
+            get_embedding(M, P), embed(M, p), embed(M, p, X), m;
             kwargs...,
         ),
     )
@@ -921,7 +921,7 @@ function retract_embedded_fused!(
         M,
         q,
         retract_fused(
-            get_embedding(M, P), embed(get_embedding(M, P), p), embed(get_embedding(M, P), p, X), t, m; kwargs...,
+            get_embedding(M, P), embed(M, p), embed(M, p, X), t, m; kwargs...,
         ),
     )
 end

--- a/src/retractions.jl
+++ b/src/retractions.jl
@@ -78,7 +78,7 @@ for point and tangent vectors.
 
 !!! note "Technical Note"
     Though you would call e.g. [`retract`](@ref)`(M, p, X, PolarRetraction())`,
-    to implement a polar retraction, define [`retract_polar!`](@ref)`(M, q, p, X, t)`
+    to implement a polar retraction, define [`retract_polar!`](@ref)`(M, q, p, X)`
     for your manifold `M`.
 """
 struct PolarRetraction <: AbstractRetractionMethod end
@@ -90,7 +90,7 @@ Retractions that are based on projection and usually addition in the embedding.
 
 !!! note "Technical Note"
     Though you would call e.g. [`retract`](@ref)`(M, p, X, ProjectionRetraction())`,
-    to implement a projection retraction, define [`retract_project!`](@ref)`(M, q, p, X, t)` for your manifold `M`.
+    to implement a projection retraction, define [`retract_project!`](@ref)`(M, q, p, X)` for your manifold `M`.
 """
 struct ProjectionRetraction <: AbstractRetractionMethod end
 
@@ -102,7 +102,7 @@ matrix / matrices for point and tangent vector on a [`AbstractManifold`](@ref)
 
 !!! note "Technical Note"
     Though you would call e.g. [`retract`](@ref)`(M, p, X, QRRetraction())`,
-    to implement a QR retraction, define [`retract_qr!`](@ref)`(M, q, p, X, t)` for your manifold `M`.
+    to implement a QR retraction, define [`retract_qr!`](@ref)`(M, q, p, X)` for your manifold `M`.
 """
 struct QRRetraction <: AbstractRetractionMethod end
 
@@ -165,7 +165,7 @@ Describes a retraction that is based on the softmax function.
 
 !!! note "Technical Note"
     Though you would call e.g. [`retract`](@ref)`(M, p, X, SoftmaxRetraction())`,
-    to implement a softmax retraction, define [`retract_softmax!`](@ref)`(M, q, p, X, t)` for your manifold `M`.
+    to implement a softmax retraction, define [`retract_softmax!`](@ref)`(M, q, p, X)` for your manifold `M`.
 """
 struct SoftmaxRetraction <: AbstractRetractionMethod end
 
@@ -198,7 +198,7 @@ A retraction based on the Padé approximation of order ``m``
 
 !!! note "Technical Note"
     Though you would call e.g. [`retract`](@ref)`(M, p, X, PadeRetraction(m))`,
-    to implement a Padé retraction, define [`retract_pade!`](@ref)`(M, q, p, X, t, m)` for your manifold `M`.
+    to implement a Padé retraction, define [`retract_pade!`](@ref)`(M, q, p, X, m)` for your manifold `M`.
 """
 struct PadeRetraction{m} <: AbstractRetractionMethod end
 
@@ -216,7 +216,7 @@ A retraction based on the Cayley transform, which is realized by using the
 
 !!! note "Technical Note"
     Though you would call e.g. [`retract`](@ref)`(M, p, X, CayleyRetraction())`,
-    to implement a Cayley retraction, define [`retract_cayley!`](@ref)`(M, q, p, X, t)` for your manifold `M`.
+    to implement a Cayley retraction, define [`retract_cayley!`](@ref)`(M, q, p, X)` for your manifold `M`.
     By default both these functions fall back to calling a [`PadeRetraction`](@ref)`(1)`.
 """
 const CayleyRetraction = PadeRetraction{1}
@@ -493,16 +493,17 @@ See also [`retract`](@ref).
 """
 function inverse_retract(
         M::AbstractManifold, p, q,
-        m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
+        m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p));
+        kwargs...
     )
-    return _inverse_retract(M, p, q, m)
+    return _inverse_retract(M, p, q, m; kwargs...)
 end
-function _inverse_retract(M::AbstractManifold, p, q, ::LogarithmicInverseRetraction)
-    return log(M, p, q)
+function _inverse_retract(M::AbstractManifold, p, q, ::LogarithmicInverseRetraction; kwargs...)
+    return log(M, p, q; kwargs...)
 end
-function _inverse_retract(M::AbstractManifold, p, q, m::AbstractInverseRetractionMethod)
+function _inverse_retract(M::AbstractManifold, p, q, m::AbstractInverseRetractionMethod; kwargs...)
     X = allocate_result(M, inverse_retract, p, q)
-    return inverse_retract!(M, X, p, q, m)
+    return inverse_retract!(M, X, p, q, m; kwargs...)
 end
 
 """
@@ -520,9 +521,10 @@ See also [`retract!`](@ref).
 """
 function inverse_retract!(
         M::AbstractManifold, X, p, q,
-        m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p)),
+        m::AbstractInverseRetractionMethod = default_inverse_retraction_method(M, typeof(p));
+        kwargs...
     )
-    return _inverse_retract!(M, X, p, q, m)
+    return _inverse_retract!(M, X, p, q, m; kwargs...)
 end
 function _inverse_retract!(
         M::AbstractManifold, X, p, q, ::LogarithmicInverseRetraction; kwargs...,
@@ -603,12 +605,12 @@ the [`AbstractInverseRetractionMethod`](@ref) `m` in the embedding (see [`get_em
 and projecting the result back.
 """
 function inverse_retract_embedded!(
-        M::AbstractManifold, X, p::P, q, m::AbstractInverseRetractionMethod,
+        M::AbstractManifold, X, p::P, q, m::AbstractInverseRetractionMethod; kwargs...,
     ) where {P}
     return project!(
         M, X, p,
         inverse_retract(
-            get_embedding(M, P), embed(M, p), embed(M, q), m,
+            get_embedding(M, P), embed(M, p), embed(M, q), m; kwargs...,
         ),
     )
 end
@@ -620,7 +622,7 @@ Compute the in-place variant of the [`CayleyInverseRetraction`](@ref),
 which by default calls the first order [`PadeInverseRetraction`§(@ref).
 """
 function inverse_retract_cayley!(M::AbstractManifold, X, p, q; kwargs...)
-    return inverse_retract_pade!(M, X, p, q, 1; kwargs...)
+    return inverse_retract_pade!(M, X, p, q, PadeInverseRetraction(1); kwargs...)
 end
 
 """
@@ -756,8 +758,8 @@ end
 function _retract!(M::AbstractManifold, q, p, X, ::QRRetraction; kwargs...)
     return retract_qr!(M, q, p, X; kwargs...)
 end
-function _retract!(M::AbstractManifold, q, p, X, m::SasakiRetraction)
-    return retract_sasaki!(M, q, p, X, m)
+function _retract!(M::AbstractManifold, q, p, X, m::SasakiRetraction; kwargs...)
+    return retract_sasaki!(M, q, p, X, m; kwargs...)
 end
 function _retract!(M::AbstractManifold, q, p, X, ::SoftmaxRetraction; kwargs...)
     return retract_softmax!(M, q, p, X; kwargs...)
@@ -797,17 +799,18 @@ By default, this falls back to calling [`retract`](@ref) with `t*X`.
 @doc "$(_doc_retract_fused)"
 function retract_fused(
         M::AbstractManifold, p, X, t::Number,
-        m::AbstractRetractionMethod = default_retraction_method(M, typeof(p)),
+        m::AbstractRetractionMethod = default_retraction_method(M, typeof(p));
+        kwargs...
     )
-    return _retract_fused(M, p, X, t, m)
+    return _retract_fused(M, p, X, t, m; kwargs...)
 end
 
-function _retract_fused(M::AbstractManifold, p, X, t::Number, ::ExponentialRetraction)
-    return exp_fused(M, p, X, t)
+function _retract_fused(M::AbstractManifold, p, X, t::Number, ::ExponentialRetraction; kwargs...)
+    return exp_fused(M, p, X, t; kwargs...)
 end
-function _retract_fused(M::AbstractManifold, p, X, t::Number, m::AbstractRetractionMethod)
-    q = allocate_result(M, retract, p, X)
-    return retract_fused!(M, q, p, X, t, m)
+function _retract_fused(M::AbstractManifold, p, X, t::Number, m::AbstractRetractionMethod; kwargs...)
+    q = allocate_result(M, retract, p, X, t)
+    return retract_fused!(M, q, p, X, t, m; kwargs...)
 end
 
 @doc "$(_doc_retract_fused)"
@@ -853,8 +856,8 @@ end
 function _retract_fused!(M::AbstractManifold, q, p, X, t::Number, ::QRRetraction; kwargs...)
     return retract_qr_fused!(M, q, p, X, t; kwargs...)
 end
-function _retract_fused!(M::AbstractManifold, q, p, X, t::Number, m::SasakiRetraction)
-    return retract_sasaki_fused!(M, q, p, X, t, m)
+function _retract_fused!(M::AbstractManifold, q, p, X, t::Number, m::SasakiRetraction; kwargs...)
+    return retract_sasaki_fused!(M, q, p, X, t, m; kwargs...)
 end
 function _retract_fused!(
         M::AbstractManifold, q, p, X, t::Number, ::SoftmaxRetraction; kwargs...,
@@ -1015,19 +1018,19 @@ Compute the in-place variant of the [`SasakiRetraction`](@ref) `m`.
 """
 retract_sasaki!(M::AbstractManifold, q, p, X, m::SasakiRetraction)
 
-function retract_sasaki_fused!(M::AbstractManifold, q, p, X, t::Number, m::SasakiRetraction)
-    return retract_sasaki!(M, q, p, t * X, m)
+function retract_sasaki_fused!(M::AbstractManifold, q, p, X, t::Number, m::SasakiRetraction; kwargs...)
+    return retract_sasaki!(M, q, p, t * X, m; kwargs...)
 end
 
-function retract_stabilized!(M::AbstractManifold, q, p, X, m::StabilizedRetraction)
-    retract!(M, q, p, X, m.retraction)
+function retract_stabilized!(M::AbstractManifold, q, p, X, m::StabilizedRetraction; kwargs...)
+    retract!(M, q, p, X, m.retraction; kwargs...)
     return embed_project!(M, q, q)
 end
 
 function retract_stabilized_fused!(
-        M::AbstractManifold, q, p, X, t::Number, m::StabilizedRetraction,
+        M::AbstractManifold, q, p, X, t::Number, m::StabilizedRetraction; kwargs...,
     )
-    retract_fused!(M, q, p, X, t, m.retraction)
+    retract_fused!(M, q, p, X, t, m.retraction; kwargs...)
     return embed_project!(M, q, q)
 end
 

--- a/src/shooting.jl
+++ b/src/shooting.jl
@@ -46,11 +46,7 @@ end
 Approximate the inverse of a retraction using the shooting method.
 """
 function inverse_retract_shooting!(
-        M::AbstractManifold,
-        X,
-        p,
-        q,
-        m::ShootingInverseRetraction;
+        M::AbstractManifold, X, p, q, m::ShootingInverseRetraction;
         kwargs...,
     )
     inverse_retract!(M, X, p, q, m.initial_inverse_retraction)

--- a/src/shooting.jl
+++ b/src/shooting.jl
@@ -36,8 +36,8 @@ struct ShootingInverseRetraction{
     max_iterations::Int
 end
 
-function _inverse_retract!(M::AbstractManifold, X, p, q, m::ShootingInverseRetraction)
-    return inverse_retract_shooting!(M, X, p, q, m)
+function _inverse_retract!(M::AbstractManifold, X, p, q, m::ShootingInverseRetraction; kwargs...)
+    return inverse_retract_shooting!(M, X, p, q, m; kwargs...)
 end
 
 """
@@ -50,7 +50,8 @@ function inverse_retract_shooting!(
         X,
         p,
         q,
-        m::ShootingInverseRetraction,
+        m::ShootingInverseRetraction;
+        kwargs...,
     )
     inverse_retract!(M, X, p, q, m.initial_inverse_retraction)
     gap = norm(M, p, X)
@@ -64,13 +65,13 @@ function inverse_retract_shooting!(
         retr_tX_new = allocate_result(M, retract, p, X)
     end
     iteration = 1
-    while (gap > m.tolerance) && (iteration < m.max_iterations)
-        retract!(M, retr_tX, p, X, m.retraction)
+    while (gap > m.tolerance) && (iteration <= m.max_iterations)
+        retract!(M, retr_tX, p, X, m.retraction; kwargs...)
         inverse_retract!(M, ΔX, retr_tX, q, m.initial_inverse_retraction)
         gap = norm(M, retr_tX, ΔX)
         for t in transport_grid
             tX .= t .* X
-            retract!(M, retr_tX_new, p, tX, m.retraction)
+            retract!(M, retr_tX_new, p, tX, m.retraction; kwargs...)
             vector_transport_to!(M, ΔXnew, retr_tX, ΔX, retr_tX_new, m.vector_transport)
             # realias storage
             retr_tX, retr_tX_new, ΔX, ΔXnew, tX = retr_tX_new, retr_tX, ΔXnew, ΔX, ΔX

--- a/src/test_suite.jl
+++ b/src/test_suite.jl
@@ -72,8 +72,7 @@ function ManifoldsBase.check_point(M::TestSphere, p; kwargs...)
 end
 function ManifoldsBase.check_vector(
         M::TestSphere, p, X;
-        atol::Real = sqrt(prod(representation_size(M))) * eps(real(float(number_eltype(X)))),
-        kwargs...,
+        atol::Real = sqrt(prod(representation_size(M))) * eps(real(float(number_eltype(X)))), kwargs...,
     )
     if !isapprox(abs(real(dot(p, X))), 0.0; atol = atol, kwargs...)
         return DomainError(
@@ -97,9 +96,7 @@ function ManifoldsBase.exp_fused!(::TestSphere, q, p, X, t::Number)
     return q
 end
 function ManifoldsBase.get_basis_diagonalizing(
-        M::TestSphere{n},
-        p,
-        B::DiagonalizingOrthonormalBasis{ℝ},
+        M::TestSphere{n}, p, B::DiagonalizingOrthonormalBasis{ℝ},
     ) where {n}
     A = zeros(n + 1, n + 1)
     A[1, :] = transpose(p)
@@ -181,11 +178,8 @@ function Random.rand!(M::TestSphere, pX; vector_at = nothing, σ = one(eltype(pX
     return rand!(Random.default_rng(), M, pX; vector_at = vector_at, σ = σ)
 end
 function Random.rand!(
-        rng::AbstractRNG,
-        M::TestSphere,
-        pX;
-        vector_at = nothing,
-        σ = one(eltype(pX)),
+        rng::AbstractRNG, M::TestSphere, pX;
+        vector_at = nothing, σ = one(eltype(pX)),
     )
     if vector_at === nothing
         project!(M, pX, randn(rng, eltype(pX), representation_size(M)))
@@ -315,9 +309,7 @@ function ManifoldsBase.number_eltype(a::NonBroadcastBasisThing)
 end
 
 function ManifoldsBase.allocate_on(
-        M::AbstractManifold,
-        ::TangentSpaceType,
-        T::Type{<:NonBroadcastBasisThing},
+        M::AbstractManifold, ::TangentSpaceType, T::Type{<:NonBroadcastBasisThing},
     )
     return NonBroadcastBasisThing(similar(T.parameters[1], representation_size(M)))
 end
@@ -337,27 +329,19 @@ end
 
 
 function ManifoldsBase.log!(
-        ::DefaultManifold,
-        X::NonBroadcastBasisThing,
-        p::NonBroadcastBasisThing,
-        q::NonBroadcastBasisThing,
+        ::DefaultManifold, X::NonBroadcastBasisThing, p::NonBroadcastBasisThing, q::NonBroadcastBasisThing,
     )
     return copyto!(X, q - p)
 end
 
 function ManifoldsBase.exp!(
-        ::DefaultManifold,
-        q::NonBroadcastBasisThing,
-        p::NonBroadcastBasisThing,
-        X::NonBroadcastBasisThing,
+        ::DefaultManifold, q::NonBroadcastBasisThing, p::NonBroadcastBasisThing, X::NonBroadcastBasisThing,
     )
     return copyto!(q, p + X)
 end
 
 function ManifoldsBase.get_basis_orthonormal(
-        ::DefaultManifold{ℝ},
-        p::NonBroadcastBasisThing,
-        𝔽::RealNumbers,
+        ::DefaultManifold{ℝ}, p::NonBroadcastBasisThing, 𝔽::RealNumbers,
     )
     return CachedBasis(
         DefaultOrthonormalBasis(𝔽),
@@ -368,9 +352,7 @@ function ManifoldsBase.get_basis_orthonormal(
     )
 end
 function ManifoldsBase.get_basis_orthogonal(
-        ::DefaultManifold{ℝ},
-        p::NonBroadcastBasisThing,
-        𝔽::RealNumbers,
+        ::DefaultManifold{ℝ}, p::NonBroadcastBasisThing, 𝔽::RealNumbers,
     )
     return CachedBasis(
         DefaultOrthogonalBasis(𝔽),
@@ -381,9 +363,7 @@ function ManifoldsBase.get_basis_orthogonal(
     )
 end
 function ManifoldsBase.get_basis_default(
-        ::DefaultManifold{ℝ},
-        p::NonBroadcastBasisThing,
-        N::ManifoldsBase.RealNumbers,
+        ::DefaultManifold{ℝ}, p::NonBroadcastBasisThing, N::ManifoldsBase.RealNumbers,
     )
     return CachedBasis(
         DefaultBasis(N),
@@ -409,10 +389,7 @@ function ManifoldsBase.get_vector_orthonormal!(
 end
 
 function ManifoldsBase.inner(
-        ::DefaultManifold,
-        ::NonBroadcastBasisThing,
-        X::NonBroadcastBasisThing,
-        Y::NonBroadcastBasisThing,
+        ::DefaultManifold, ::NonBroadcastBasisThing, X::NonBroadcastBasisThing, Y::NonBroadcastBasisThing,
     )
     return dot(X.v, Y.v)
 end
@@ -468,16 +445,12 @@ function ManifoldsBase.allocate_result(::DefaultManifold, ::typeof(zero_vector),
     return DefaultTangentVector(allocate(p.value))
 end
 function ManifoldsBase.allocate_result_type(
-        ::DefaultManifold,
-        ::typeof(log),
-        ::Tuple{DefaultPoint, DefaultPoint},
+        ::DefaultManifold, ::typeof(log), ::Tuple{DefaultPoint, DefaultPoint},
     )
     return DefaultTangentVector
 end
 function ManifoldsBase.allocate_result_type(
-        ::DefaultManifold,
-        ::typeof(inverse_retract),
-        ::Tuple{DefaultPoint, DefaultPoint},
+        ::DefaultManifold, ::typeof(inverse_retract), ::Tuple{DefaultPoint, DefaultPoint},
     )
     return DefaultTangentVector
 end
@@ -614,9 +587,7 @@ struct TestArrayRepresentation <: AbstractPowerRepresentation end
 
 const TestPowerManifoldMultidimensional = AbstractPowerManifold{𝔽, <:AbstractManifold{𝔽}, TestArrayRepresentation} where {𝔽}
 
-function ManifoldsBase.representation_size(
-        M::TestPowerManifoldMultidimensional,
-    )
+function ManifoldsBase.representation_size(M::TestPowerManifoldMultidimensional)
     return (representation_size(M.manifold)..., ManifoldsBase.get_parameter(M.size)...)
 end
 

--- a/src/test_suite.jl
+++ b/src/test_suite.jl
@@ -70,8 +70,12 @@ function ManifoldsBase.check_point(M::TestSphere, p; kwargs...)
     end
     return nothing
 end
-function ManifoldsBase.check_vector(M::TestSphere, p, X; kwargs...)
-    if !isapprox(abs(real(dot(p, X))), 0.0; kwargs...)
+function ManifoldsBase.check_vector(
+        M::TestSphere, p, X;
+        atol::Real = sqrt(prod(representation_size(M))) * eps(real(float(number_eltype(X)))),
+        kwargs...,
+    )
+    if !isapprox(abs(real(dot(p, X))), 0.0; atol = atol, kwargs...)
         return DomainError(
             abs(dot(p, X)),
             "The vector $(X) is not a tangent vector to $(p) on $(M), since it is not orthogonal in the embedding.",

--- a/src/vector_spaces.jl
+++ b/src/vector_spaces.jl
@@ -133,7 +133,9 @@ Base.:-(X::FVector) = FVector(X.type, -X.data, X.basis)
 Base.:-(::ZeroVector) = ZeroVector()
 
 Base.:*(a::Number, X::FVector) = FVector(X.type, a * X.data, X.basis)
+Base.:*(X::FVector, a::Number) = FVector(X.type, X.data * a, X.basis)
 Base.:*(::Number, ::ZeroVector) = ZeroVector()
+Base.:*(::ZeroVector, ::Number) = ZeroVector()
 
 allocate(x::FVector) = FVector(x.type, allocate(x.data), x.basis)
 allocate(x::FVector, ::Type{T}) where {T} = FVector(x.type, allocate(x.data, T), x.basis)

--- a/src/vector_transport.jl
+++ b/src/vector_transport.jl
@@ -129,8 +129,7 @@ struct PoleLadderTransport{
     retraction::RT
     inverse_retraction::IRT
     function PoleLadderTransport(
-            retraction = ExponentialRetraction(),
-            inverse_retraction = LogarithmicInverseRetraction(),
+            retraction = ExponentialRetraction(), inverse_retraction = LogarithmicInverseRetraction(),
         )
         return new{typeof(retraction), typeof(inverse_retraction)}(
             retraction,
@@ -202,8 +201,7 @@ struct SchildsLadderTransport{
     retraction::RT
     inverse_retraction::IRT
     function SchildsLadderTransport(
-            retraction = ExponentialRetraction(),
-            inverse_retraction = LogarithmicInverseRetraction(),
+            retraction = ExponentialRetraction(), inverse_retraction = LogarithmicInverseRetraction(),
         )
         return new{typeof(retraction), typeof(inverse_retraction)}(
             retraction,
@@ -349,8 +347,7 @@ each., since the center `c` can be reused.
 """
 function pole_ladder(
         M, p, d, q, c = mid_point(M, p, q);
-        retraction = default_retraction_method(M, typeof(p)),
-        inverse_retraction = default_inverse_retraction_method(M, typeof(p)),
+        retraction = default_retraction_method(M, typeof(p)), inverse_retraction = default_inverse_retraction_method(M, typeof(p)),
     )
     return retract(M, d, 2 * inverse_retract(M, d, c, inverse_retraction), retraction)
 end
@@ -366,8 +363,7 @@ Compute the [`pole_ladder`](@ref), i.e. the result is saved in `pl`.
 """
 function pole_ladder!(
         M, pl, p, d, q, c = mid_point(M, p, q), X = allocate_result(M, log, d, c);
-        retraction = default_retraction_method(M, typeof(p)),
-        inverse_retraction = default_inverse_retraction_method(M, typeof(p)),
+        retraction = default_retraction_method(M, typeof(p)), inverse_retraction = default_inverse_retraction_method(M, typeof(p)),
     )
     inverse_retract!(M, X, d, c, inverse_retraction)
     X *= 2
@@ -407,8 +403,7 @@ $Y_n = \log_q \operatorname{Pl}(p_{n-1},d_{n-1},p_n)$.
 """
 function schilds_ladder(
         M, p, d, q, c = mid_point(M, q, d);
-        retraction = default_retraction_method(M, typeof(p)),
-        inverse_retraction = default_inverse_retraction_method(M, typeof(p)),
+        retraction = default_retraction_method(M, typeof(p)), inverse_retraction = default_inverse_retraction_method(M, typeof(p)),
     )
     return retract(M, p, 2 * inverse_retract(M, p, c, inverse_retraction), retraction)
 end
@@ -426,8 +421,7 @@ for the interims result.
 """
 function schilds_ladder!(
         M, sl, p, d, q, c = mid_point(M, q, d), X = allocate_result(M, log, d, c);
-        retraction = default_retraction_method(M, typeof(p)),
-        inverse_retraction = default_inverse_retraction_method(M, typeof(p)),
+        retraction = default_retraction_method(M, typeof(p)), inverse_retraction = default_inverse_retraction_method(M, typeof(p)),
     )
     inverse_retract!(M, X, p, c, inverse_retraction)
     X *= 2
@@ -478,14 +472,12 @@ By default [`vector_transport_direction`](@ref) falls back to using [`vector_tra
 using the [`default_retraction_method`](@ref) on `M`.
 """
 function vector_transport_direction(
-        M::AbstractManifold, p, X, d,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::AbstractManifold, p, X, d, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     return _vector_transport_direction(M, p, X, d, m)
 end
 function _vector_transport_direction(
-        M::AbstractManifold, p, X, d,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p));
+        M::AbstractManifold, p, X, d, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p));
         kwargs...,
     )
     # allocate first
@@ -522,15 +514,13 @@ The result is saved to `Y`.
 See [`vector_transport_direction`](@ref) for more details.
 """
 function vector_transport_direction!(
-        M::AbstractManifold, Y, p, X, d,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p));
+        M::AbstractManifold, Y, p, X, d, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p));
         kwargs...,
     )
     return _vector_transport_direction!(M, Y, p, X, d, m; kwargs...)
 end
 function _vector_transport_direction!(
-        M::AbstractManifold, Y, p, X, d,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p));
+        M::AbstractManifold, Y, p, X, d, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p));
         kwargs...,
     )
     r = default_retraction_method(M, typeof(p))
@@ -620,8 +610,7 @@ This method is equivalent to using ``d = \operatorname{retr}^{-1}_p(q)`` in [`ve
 where you can find the formal definition. This is the fallback for [`VectorTransportTo`](@ref).
 """
 function vector_transport_to(
-        M::AbstractManifold, p, X, q,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::AbstractManifold, p, X, q, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     return _vector_transport_to(M, p, X, q, m)
 end
@@ -660,8 +649,7 @@ The result is computed in `Y`.
 See [`vector_transport_to`](@ref) for more details.
 """
 function vector_transport_to!(
-        M::AbstractManifold, Y, p, X, q,
-        m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
+        M::AbstractManifold, Y, p, X, q, m::AbstractVectorTransportMethod = default_vector_transport_method(M, typeof(p)),
     )
     return _vector_transport_to!(M, Y, p, X, q, m)
 end
@@ -773,8 +761,7 @@ end
 
 # default estimation fallbacks with and without the T
 function default_approximation_method(
-        M::AbstractManifold,
-        ::typeof(vector_transport_direction),
+        M::AbstractManifold, ::typeof(vector_transport_direction),
     )
     return default_vector_transport_method(M)
 end

--- a/src/vector_transport.jl
+++ b/src/vector_transport.jl
@@ -597,7 +597,7 @@ function vector_transport_direction_embedded!(
         M::AbstractManifold, Y, p::P, X, d, m::AbstractVectorTransportMethod,
     ) where {P}
     p_e = embed(M, p)
-    d_e = embed(M, d)
+    d_e = embed(M, p, d)
     X_e = embed(M, p, X)
     Y_e = vector_transport_direction(get_embedding(M, P), p_e, X_e, d_e, m)
     q = exp(M, p, d)
@@ -640,7 +640,8 @@ function _vector_transport_to(
         kwargs...,
     )
     Y = allocate_result(M, vector_transport_to, X, p)
-    return vector_transport_to!(M, Y, p, X, q, m; kwargs...)
+    v = length(kwargs) > 0 ? VectorTransportWithKeywords(m; kwargs...) : m
+    return vector_transport_to!(M, Y, p, X, q, v)
 end
 function _vector_transport_to(
         M::AbstractManifold, p, X, q, m::VectorTransportWithKeywords; kwargs...,

--- a/test/bases.jl
+++ b/test/bases.jl
@@ -409,6 +409,8 @@ using Test
         @test (-fv1).type == TangentSpaceType()
         @test isa(2 * fv1, FVector)
         @test (2 * fv1).type == TangentSpaceType()
+        @test isa(fv1 * 2, FVector)
+        @test (fv1 * 2).type == TangentSpaceType()
         tv1s_32 = allocate(fv_tvs[1], Float32)
         @test isa(tv1s, FVector)
         @test eltype(tv1s_32.data) === Float32

--- a/test/default_manifold.jl
+++ b/test/default_manifold.jl
@@ -8,6 +8,13 @@ using ReverseDiff
 using StaticArrays
 using Test
 
+# `vector_transport_to_diff!` has no generic implementation, so give the reference manifold one
+function ManifoldsBase.vector_transport_to_diff!(
+        ::ManifoldsBase.DefaultManifold, Y, p, X, q, r,
+    )
+    return copyto!(Y, X)
+end
+
 @testset "Testing Default (Euclidean)" begin
     M = ManifoldsBase.DefaultManifold(3)
     types = [
@@ -495,6 +502,11 @@ using Test
         @test (Y .= X) === Y
         # vector transport pass through
         @test vector_transport_to(M, p, X, q, ProjectionTransport()) == X
+        @test vector_transport_to(M, p, X, q, EmbeddedVectorTransport(ProjectionTransport())) ==
+            X
+        @test vector_transport_to(
+            M, p, X, q, DifferentiatedRetractionVectorTransport(ExponentialRetraction()),
+        ) == X
         @test vector_transport_direction(M, p, X, X, ProjectionTransport()) == X
         @test vector_transport_to!(M, Y, p, X, q, ProjectionTransport()) == X
         @test vector_transport_direction!(M, Y, p, X, X, ProjectionTransport()) == X

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -1,6 +1,15 @@
 using LinearAlgebra, ManifoldsBase, Test
 
 using ManifoldsBase: DefaultManifold, ℝ
+
+struct ProjectionBaseManifold <: AbstractManifold{ℝ} end
+ManifoldsBase.representation_size(::ProjectionBaseManifold) = (2,)
+ManifoldsBase.manifold_dimension(::ProjectionBaseManifold) = 2
+function ManifoldsBase.project!(
+        ::EmbeddedManifold{ℝ, ProjectionBaseManifold}, Y, p, X,
+    )
+    return copyto!(Y, X[1:2])
+end
 #
 # A first artificial (not real) manifold that is modelled as a submanifold
 # half plane with euclidean metric is not a manifold but should test all things correctly here
@@ -494,6 +503,11 @@ end
         @test_throws DomainError embed!(O, zeros(3, 3), zeros(4, 4))
         @test_throws DomainError project!(O, zeros(3, 3, 5), zeros(3, 3))
         @test_throws DomainError project!(O, zeros(4, 4), zeros(3, 3))
+        # the allocating tangent projection allocates in the size of the base manifold
+        O3 = EmbeddedManifold(ProjectionBaseManifold(), DefaultManifold(3))
+        Y3 = project(O3, [1.0, 2.0, 0.0], [4.0, 5.0, 9.0])
+        @test size(Y3) == (2,)
+        @test Y3 == [4.0, 5.0]
     end
     @testset "Explicit Fallback" begin
         M = FallbackManifold()

--- a/test/embedded_manifold.jl
+++ b/test/embedded_manifold.jl
@@ -419,16 +419,16 @@ end
             @test @inferred !isapprox(M, [1, 2], [2, 3])
             @test @inferred !isapprox(M, [1, 2], [2, 3], [4, 5])
 
-            @test ManifoldsBase.get_forwarding_type_embedding(ManifoldsBase.EmbeddedSubmanifoldType{ManifoldsBase.DirectEmbedding}(), M, exp) === EmbeddedForwardingType()
+            @test ManifoldsBase.get_forwarding_type_embedding(ManifoldsBase.EmbeddedSubmanifoldType{ManifoldsBase.DirectEmbedding}(), M, exp) === EmbeddedForwardingType(ManifoldsBase.DirectEmbedding())
         end
         @testset "Isometric Embedding Fallbacks & Error Tests" begin
             for M2 in [NotImplementedIsometricEmbeddedManifoldNE(), NotImplementedIsometricEmbeddedManifoldIsoIndirect()]
                 @test base_manifold(M2) == M2
                 A = zeros(2)
                 if M2 isa NotImplementedIsometricEmbeddedManifoldIsoIndirect
-                    @test_throws MethodError ManifoldsBase.allocate_result(M2, zero_vector, A)
-                else
                     @test size(ManifoldsBase.allocate_result(M2, zero_vector, A)) == size(A)
+                else
+                    @test_throws MethodError ManifoldsBase.allocate_result(M2, zero_vector, A)
                 end
                 # Check that all of these report not to be implemented, i.e.
                 @test_throws MethodError exp(M2, [1, 2], [2, 3])

--- a/test/fibers.jl
+++ b/test/fibers.jl
@@ -59,7 +59,7 @@ using ManifoldsBase: DefaultManifold, VectorSpaceType, ℝ, Fiber
         # generic vector space at
         X_p = Fiber(M, p, ManifoldsBase.Test.TestVectorSpaceType())
         X_ps = sprint(show, "text/plain", X_p)
-        X_ps_test = "VectorSpaceFiber{ℝ, DefaultManifold{ℝ, Tuple{Int64}}, ManifoldsBase.Test.TestVectorSpaceType, Vector{Float64}}\nFiber:\n ManifoldsBase.Test.TestVectorSpaceType()DefaultManifold(3; field = ℝ)\nBase point:\n $(sp)"
+        X_ps_test = "VectorSpaceFiber{ℝ, DefaultManifold{ℝ, Tuple{Int64}}, ManifoldsBase.Test.TestVectorSpaceType, Vector{Float64}}\nFiber:\n ManifoldsBase.Test.TestVectorSpaceType()\n DefaultManifold(3; field = ℝ)\nBase point:\n $(sp)"
         @test X_ps == X_ps_test
 
         for basis in

--- a/test/numerical_checks.jl
+++ b/test/numerical_checks.jl
@@ -187,11 +187,9 @@ default(; show = false, reuse = true)
         @test is_point(M, p4; error = :error)
         @test is_point(M, p5; error = :error)
         # test the inverse as well
-        # `log(M, p6, p7)` is orthogonal to `p6` by construction, since `p6` has unit norm,
-        # so it carries the same residual as the two stabilized variants below
-        @test is_vector(M, p6, Y1; error = :error, atol = 1.0e-16)
-        @test is_vector(M, p6, Y2; error = :error, atol = 1.0e-16)
-        @test is_vector(M, p6, Y3; error = :error, atol = 1.0e-16)
+        @test is_vector(M, p6, Y1; error = :error)
+        @test is_vector(M, p6, Y2; error = :error)
+        @test is_vector(M, p6, Y3; error = :error)
     end
     @testset "Slope estimation with errors down to round-off" begin
         log_range = collect(range(-8.0, 0.0; length = 101))

--- a/test/numerical_checks.jl
+++ b/test/numerical_checks.jl
@@ -187,7 +187,9 @@ default(; show = false, reuse = true)
         @test is_point(M, p4; error = :error)
         @test is_point(M, p5; error = :error)
         # test the inverse as well
-        @test !is_vector(M, p6, Y1)
+        # `log(M, p6, p7)` is orthogonal to `p6` by construction, since `p6` has unit norm,
+        # so it carries the same residual as the two stabilized variants below
+        @test is_vector(M, p6, Y1; error = :error, atol = 1.0e-16)
         @test is_vector(M, p6, Y2; error = :error, atol = 1.0e-16)
         @test is_vector(M, p6, Y3; error = :error, atol = 1.0e-16)
     end

--- a/test/numerical_checks.jl
+++ b/test/numerical_checks.jl
@@ -190,6 +190,7 @@ default(; show = false, reuse = true)
         @test is_vector(M, p6, Y1; error = :error)
         @test is_vector(M, p6, Y2; error = :error)
         @test is_vector(M, p6, Y3; error = :error)
+        @test !is_vector(M, p6, p6)
     end
     @testset "Slope estimation with errors down to round-off" begin
         log_range = collect(range(-8.0, 0.0; length = 101))

--- a/test/power.jl
+++ b/test/power.jl
@@ -318,7 +318,7 @@ end
                     B3 = get_basis(N, p, B2)
                     if pow_size == (2,)
                         @test sprint(show, "text/plain", B) ==
-                            """$(DefaultBasis()) for a power manifold
+                            """$(typeof(DefaultBasis())) for a power manifold
                             Basis for component (1,):
                             $(sprint(show, "text/plain", B.data.bases[1]))
                             Basis for component (2,):

--- a/test/power.jl
+++ b/test/power.jl
@@ -240,6 +240,9 @@ end
                     @test norm(N, p, q, Inf) == maximum(norms)
                     @test project(N, p) == p
                     @test project(N, p, q) == q
+                    Zp = allocate(q)
+                    @test project!(N, Zp, p, q) == q
+                    @test Zp == q
                     @test power_dimensions(N) == pow_size
                     @test power_dimensions(N^3) == (pow_size..., 3)
                     m = ParallelTransport()

--- a/test/test_zerovector.jl
+++ b/test/test_zerovector.jl
@@ -12,7 +12,7 @@ using ManifoldsBase, Test
     @test -X == X
     @test allocate(X) == ZeroVector()
     @test 1.0 * X == X
-    @test 0.1 * X == X
+    @test X * 0.1 == X
 
     M = ManifoldsBase.DefaultManifold(3)
     p = [0.0, 1.0, 2.0]

--- a/test/validation_manifold.jl
+++ b/test/validation_manifold.jl
@@ -225,12 +225,26 @@ using ManifoldsBase, LinearAlgebra, Random, Test
         @test distance(AdN, [], []) == -1.0
         @test norm(AdN, [], []) == -1.0
     end
+    @testset "wrapped points and tangent vectors are unwrapped when forwarded" begin
+        pw = ValidationMPoint(x)
+        Xw = ValidationTangentVector(w)
+        B = DefaultOrthonormalBasis()
+        # get_coordinates has to accept the wrapped values, like get_coordinates! does
+        @test get_coordinates(A, pw, Xw, B) ≈ get_coordinates(M, x, w, B)
+        @test get_coordinates(A, pw, w, B) ≈ get_coordinates(M, x, w, B)
+        @test get_coordinates(A, x, Xw, B) ≈ get_coordinates(M, x, w, B)
+        c = get_coordinates(M, x, w, B)
+        @test get_vector(A, pw, c, B) ≈ get_vector(M, x, c, B)
+    end
     @testset "rand" begin
         Random.seed!(42)
         p = rand(A)
         @test is_point(A, p)
         X = rand(A; vector_at = p)
         @test is_vector(A, p, X)
+        # a wrapped point has to be accepted as `vector_at` as well
+        Xw = rand(A; vector_at = ValidationMPoint(p))
+        @test is_vector(A, p, Xw)
     end
     @testset "embed and project" begin
         Dm = ManifoldsBase.Test.ValidationDummyManifold()


### PR DESCRIPTION
I currently have the opportunity to get a bit annoyed by AI.

It at least finds a few loopholes and bugs along the way. 
This is the same approach already done in https://github.com/JuliaManifolds/Manopt.jl/pull/643, that I plan to do at least once (maybe not 3-4 times like there) here.

But I want to start even more transparent here, so I will post the current progress and the initial report already in this initial comment.

I did ask Claude to check the code for inaccuracies, typos, bugs – and to check the reports posted on the PR above for the general approach that it only writes reports and does not modify code itself – only if I specifically ask it to apply a change for example. That produced some 18k lines of a report – so I asked why it is so long and it reduced several self checks and so on.
That report is attached here for transparency.

From the first 22 (called severe) it claims one Manifold (Unitary) might fail due to the fix, since it implements an allocating variant somewhere. We should maybe check that – the fix proposed (and applied) seems correct to always first allocate – call the mutating variant – and only then pass from OGB to ONB.

The current status is

| severity | items | fixed | rejected | open | range |
|---|---|---|---|---|---|
| high | 22 | 22 | 0 | 0 | 1–22 |
| medium | 120 | 37 | 1 | 82 | 23–142 |
| low | 191 | 0 | 0 | 191 | 143–333 |

Fixed so far: 1–45, 47–60. Rejected: 46.

In my experience both medium and low are usually mainly small typos and are even faster to apply than the 22 severe noes (which now took me about 90 minutes to carefully read, assess, rephrase slightly and let them be applied).

[report_orig.md](https://github.com/user-attachments/files/32059844/report_orig.md)
